### PR TITLE
rename default multiqc report output (Fixes #31)

### DIFF
--- a/modules/Fastqc/fastqc.nf
+++ b/modules/Fastqc/fastqc.nf
@@ -33,7 +33,7 @@ process multiqc {
     
     publishDir "${params.output}/QC_analysis/", mode: 'copy',
         saveAs: { filename ->
-            if(filename.indexOf("multiqc_data/*") > 0) "MultiQC_stats/multiqc_data/$filename"
+            if(filename.indexOf("multiqc_report_data/*") > 0) "MultiQC_stats/multiqc_data/$filename"
             else if(filename.indexOf("general_stats.txt") > 0) "MultiQC_stats/$filename"
             else if(filename.indexOf("_report.html") > 0) "MultiQC_stats/$filename"
             else {}
@@ -46,12 +46,12 @@ process multiqc {
     output:
         path 'multiqc_report.html'
         path 'multiqc_general_stats.txt'
-        path 'multiqc_data/'
+        path 'multiqc_report_data/'
 
     script:
     """
     cp $config/* .
-    multiqc -v data* --interactive -f --cl-config "max_table_rows: 3000"
-    mv multiqc_data/multiqc_general_stats.txt .
+    multiqc -v data* --interactive -f --cl-config "max_table_rows: 3000" -n multiqc_report
+    mv multiqc_report_data/multiqc_general_stats.txt .
     """
 }


### PR DESCRIPTION
This aims to fix #31 

With the current version of `multiqc` the report html and data directory include the config title (taken from `data/multiqc/multiqc_config.yaml`) in their path, i.e.:

```
multiqc_data/ -> AMR-Bioinformatic-pipeline_multiqc_report_data
and 
multiqc_report.html -> AMR-Bioinformatic-pipeline_multiqc_report.html
```

This PR tells multiqc to use the filename `multiqc_report` instead of including the config title in the names, and moves everything in a similar place as before.


@EnriqueDoster Let me know if you'd like it better if the multiqc version is getting fixed to 1.6 as mentioned in the docpage [here](https://github.com/Microbial-Ecology-Group/AMRplusplus/blob/master/docs/dependencies.md). I could then close this PR and open a new one fixing the version in the env-file here [envs/AMR++_env.yaml#L9](https://github.com/Microbial-Ecology-Group/AMRplusplus/blob/master/envs/AMR%2B%2B_env.yaml#L9)
