### PR TITLE
Added apptainer to -profile

### DIFF
--- a/config/apptainer.config
+++ b/config/apptainer.config
@@ -1,0 +1,8 @@
+process {
+  executor = 'local'           // The type of system the processes are being run on (do not modify this)
+  maxForks = 4                 // The maximum number of forks a single process is allowed to spawn
+  container = 'enriquedoster/amrplusplus:latest'
+  withLabel: 'qiime2' { 
+      container = 'enriquedoster/qiime2:latest'
+  }
+}

--- a/docs/FAQs.md
+++ b/docs/FAQs.md
@@ -5,7 +5,7 @@ Many errors that may be encountered may ultimately be the result of user error. 
 
 * Are you using the correct "profile" to run AmrPlusPlus?
   * We provide many examples of profile configurationg and choosing the correct one depends on your computing environment.
-    * If you have singularity or installed on your server, we recommend using the "singularity" or profile to avoid the installation of any additional tools. 
+    * If you have singularity installed on your server, we recommend using the "singularity" profile to avoid the installation of any additional tools. 
     * If you already have the tools installed on your server, the best option is to configure the local.config file to point to the absolute PATH to each too.
 * Are the right user permissions are granted to the file/directory/server in which you are going to run the pipeline?
   * In servers with multiple users, there are often cases in which certain directories give some users more editing privileges than others. Start by navigating to the directory in which you will be working. Next, type “ls -lha or ls -l”. This produces a list of all files in that directory and info on what permissions the user has using the “-rwxrwxrwx” scheme; r = read permissions, w = writing permissions, and x = execute permissions).

--- a/docs/FAQs.md
+++ b/docs/FAQs.md
@@ -5,12 +5,10 @@ Many errors that may be encountered may ultimately be the result of user error. 
 
 * Are you using the correct "profile" to run AmrPlusPlus?
   * We provide many examples of profile configurationg and choosing the correct one depends on your computing environment.
-    * If you have singularity installed on your server, we recommend using the "singularity" profile to avoid the installation of any additional tools. 
+    * If you have singularity or installed on your server, we recommend using the "singularity" or profile to avoid the installation of any additional tools. 
     * If you already have the tools installed on your server, the best option is to configure the local.config file to point to the absolute PATH to each too.
-
 * Are the right user permissions are granted to the file/directory/server in which you are going to run the pipeline?
   * In servers with multiple users, there are often cases in which certain directories give some users more editing privileges than others. Start by navigating to the directory in which you will be working. Next, type “ls -lha or ls -l”. This produces a list of all files in that directory and info on what permissions the user has using the “-rwxrwxrwx” scheme; r = read permissions, w = writing permissions, and x = execute permissions).
   * Permission errors could be due to the directories chosen for the pipeline output or individual bioinformatic tools installed by other users, for example. 
   * Review this tutorial for more information regarding file permissions: https://www.guru99.com/file-permissions.html
-
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,7 +26,7 @@ The **params.config** contains parameters that control which files are being ana
 
 The **nextflow.config** contains a section that allows the use of environment "profiles" when running AmrPlusPlus. Further information for each profile can be found within the /config directory. In brief, profiles allow control over how the pipeline is run on different computing clusters. We recommend the "singularity" profile which employs singularity containers which contain all the required bioinformatic tools.
 
-We make the following profiles available to suit your computing needs; "local", "local_slurm", "conda","conda_slurm", "singularity", "singularity_slurm", and "docker". You specify which profile to use with the ```-profile`` flag.
+We make the following profiles available to suit your computing needs; "local", "local_slurm", "conda","conda_slurm", "singularity", "apptainer", "singularity_slurm", and "docker". You specify which profile to use with the ```-profile`` flag.
 
 
 ```bash
@@ -55,6 +55,12 @@ profiles {
     singularity.enabled = true
     singularity.autoMounts = true
     singularity.cacheDir = "$baseDir/envs/"
+  }
+   apptainer {
+    includeConfig "config/apptainer.config"
+    apptainer.enabled = true
+    apptainer.autoMounts = true
+    apptainer.cacheDir = "$baseDir/envs/"
   }
   conda_slurm {
     includeConfig "config/conda_slurm.config"
@@ -166,7 +172,7 @@ By default, the pipeline uses the default minikraken database (~4GB) to classify
 
 ```bash
  sh download_minikraken.sh
- ```
+```
 
 If you would like to use a custom database or the standard Kraken database (~160GB), you will need to build it yourself and modify the **kraken_db** environment variable in the ```params.config ``` file to point to its location on your machine. 
 
@@ -195,37 +201,37 @@ Main pipeline options
   * Standard AMR pipeline ( QC trimming > Host DNA removal > Resistome alignment > Resistome results)
     ```bash
     --pipeline standard_AMR
-    ```  
+    ```
   * Fast AMR pipeline (QC trimming > Resistome alignment > Resistome results)
     ```bash
     --pipeline fast_AMR
-    ``` 
+    ```
   * AMR pipeline with kraken ( QC trimming > Host DNA removal > Resistome alignment > Resistome results) & (Non-host reads > Microbiome analysis)
     ```bash
     --pipeline standard_AMR_wKraken
-    ``` 
+    ```
   * 16S Microbiome analysis with qiime2 (DADA2 QC > Classification with SILVA)
     ```bash
     --pipeline qiime2
-    ``` 
-Pipeline components
+    ```
+    Pipeline components
   * Evaluate QC with multiQC
     ```bash
     --pipeline eval_qc
-    ``` 
+    ```
   * QC trimming with trimmomatic
     ```bash
     --pipeline trim_qc
-    ``` 
+    ```
   * Align reads to host DNA and remove contaminants
     ```bash
     --pipeline rm_host
-    ``` 
+    ```
   * Only perform AMR++ resistome analysis
     ```bash
     --pipeline resistome
-    ``` 
+    ```
   * Only perform microbiome analysis with Kraken
     ```bash
     --pipeline kraken
-    ``` 
+    ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -134,7 +134,7 @@ Requirements:
 * Nextflow
 * Apptainer
 
-Apptainer is the opensourc fork of singularity that is a part of the linux project. Sometimes HPCs might have apptainer intstalled rather than singularity, this will allow AMR++ to download and use a singularity/apptainer container with all of the pre-installed software requirements.
+Apptainer is the opensourc fork of singularity that is a part of the linux project. Sometimes HPCs might have apptainer intstalled rather than singularity. This configuration will allow AMR++ to download and use a singularity/apptainer container with all of the pre-installed software requirements.
 
 ```bash
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,6 +14,7 @@ To make all of the bioinformatic tool dependencies available for use with AMR++,
   - [Run AMR++ with anaconda](#run-amr-with-anaconda)
     - [Installing miniconda without "sudo" permissions.](#installing-miniconda-without-sudo-permissions)
   - [Run AMR++ using Singularity](#run-amr-using-singularity)
+  - [Run AMR++ using Apptainer](#Run-amr-using-apptainer)
   - [Run AMR++ using Docker](#run-amr-using-docker)
   - [Local installation of tools](#local-installation-of-tools)
 
@@ -127,6 +128,33 @@ nextflow run main_AMR++.nf -profile local -with-singularity amrplusplus_latest.s
 
 ```
 
+## Run AMR++ using Apptainer
+
+Requirements:
+* Nextflow
+* Apptainer
+
+Apptainer is the opensourc fork of singularity that is a part of the linux project. Sometimes HPCs might have apptainer intstalled rather than singularity, this will allow AMR++ to download and use a singularity/apptainer container with all of the pre-installed software requirements.
+
+```bash
+
+# Download AMR++ repository
+git clone https://github.com/Microbial-Ecology-Group/AMRplusplus.git
+
+# Navigate into direcotry
+cd AMRplusplus
+
+# Run command with singularity profile
+nextflow run main_AMR++.nf -profile apptainer
+
+# Alternatively, you can pull the singularity container first like this:
+singularity pull docker://enriquedoster/amrplusplus:latest
+
+# Then, specify the path to the singularity image.
+nextflow run main_AMR++.nf -profile local -with-apptainer amrplusplus_latest.sif
+
+```
+
 ## Run AMR++ using Docker
 
 Requirements:
@@ -161,4 +189,4 @@ If you run into issues with using Miniconda and Singularity, or perhaps your com
 
 ```bash
 nextflow run main_AMR++.nf -profile local
- ```
+```

--- a/main_AMR++.nf
+++ b/main_AMR++.nf
@@ -51,6 +51,7 @@ def helpMessage = """\
         - conda: Uses "mamba" to install a conda environment. 
         - conda_slurm: Uses "mamba" and adds control over slurm job submission.
         - singularity: Uses a "singularity" image container.
+        - apptainer: Uses a "Singularity" (.sif) image container with the apptainer container system. 
         - singularity_slurm: Singularity image and adds control over slurm job submission.
         - docker: Uses a docker image container.
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -55,7 +55,7 @@ profiles {
     singularity.autoMounts = true
     singularity.cacheDir = "$baseDir/envs/"
   }
-    apptainer {
+  apptainer {
     includeConfig "config/apptainer.config"
     apptainer.enabled = true
     apptainer.autoMounts = true

--- a/nextflow.config
+++ b/nextflow.config
@@ -55,6 +55,12 @@ profiles {
     singularity.autoMounts = true
     singularity.cacheDir = "$baseDir/envs/"
   }
+    apptainer {
+    includeConfig "config/apptainer.config"
+    apptainer.enabled = true
+    apptainer.autoMounts = true
+    apptainer.cacheDir = "$baseDir/envs/"
+  }
   conda_slurm {
     includeConfig "config/conda_slurm.config"
     conda.cacheDir = "$baseDir/envs/"


### PR DESCRIPTION
Apptainer is the open source flavour of singularity, it is compatible with singularity .sif files and is supported by Nextflow with the same parameters as singularity.

https://www.nextflow.io/docs/latest/container.html

This pull request has adds the config files for apptainer and updates the documents to reflect this. 

Users should be able to use the flag `-profile apptainer` in the same way they can for singularity and conda. 

Has been verified using the default demo data.