### PR TITLE
Integrating new changes from Dev branch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ conda env create -f envs/AMR++_env.yaml
 # This can take 5-10 mins (or more) depending on your internet speed, computing resources, etc. 
 
 # Once it's completed, activate the environment
-conda activate AMR++_env.yaml
+conda activate AMR++_env
 
 # You now have access to all the AMR++ software dependencies (locally)
 samtools --help

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Brief overview:
 More Information
 ----------------
 
+- [Getting Started](docs/GettingStarted.md)
 - [Installation](https://github.com/Microbial-Ecology-Group/AMRplusplus/blob/master/docs/installation.md)
 - [Usage](https://github.com/Microbial-Ecology-Group/AMRplusplus/blob/master/docs/usage.md)
   - [Choosing the right pipeline](docs/choosing_pipeline.md)
@@ -116,7 +117,9 @@ Here are some tutorials to run each analysis step by step:
 
 - [Paired-end analysis step-by-step](docs/Step_by_step_tutorial.md)
 - [Single-end analysis step-by-step](docs/SingleEnd_read_tutorial.md)
-- [Merged-read analysis step-by-step](docs/Merged_read_tutorial.md) 
+- [Merged-read analysis step-by-step](docs/Merged_read_tutorial.md)
+
+> **Tip:** Always run the demo first (`--pipeline demo`) before your first analysis. See [Getting Started](docs/GettingStarted.md) for an explanation of the work directory, SLURM setup, and conda vs local profiles.
 
 
 # Optional flags

--- a/README.md
+++ b/README.md
@@ -22,10 +22,23 @@ With AMR++, you will obtain alignment count files for each sample that are combi
 [Detailed changes here.](docs/CHANGELOG.md)
 
 Brief overview:
-1. Switch to only counting primary resistome alignments. 
-2. Changed default AMR gene fraction ```--threshold``` to `0`. We recommend running statistical analysis of count matrices after aggregating to the "Group" level to account for possible false-positive calls of individual gene accessions. 
-3. Added single-end and merged-read analysis.
-4. Changed defaults to skip rarefaction analysis, but default to running the SNP confirmation and deduplication of resistome counts.
+1. **Resistome counting now uses `alignment_analyzer.py` (AlignmentAnalyzer), replacing the compiled `resistomeanalyzer` binary.** The new analyzer reads the BAM directly and produces the gene-level count matrix, with several improvements to *how* alignments are turned into counts (items 2–4 below). The old `resistomeanalyzer` binary is no longer used for gene counting.
+2. **Fragment-level counting — a major change to how hits are counted.** AMR++ now counts at the *fragment* level rather than counting every read as a separate hit.
+   - Previously: every aligned read counted as one hit, so a paired-end fragment (R1 + R2) could be counted twice while a merged read counted once — inflating and skewing counts between library types.
+   - Now: a read pair and a merged read each count as **one hit**, so paired-end and merged data are directly comparable. This is the default (`count_mode = "fragment"`).
+   - When a fragment's two mates map to different-but-near-identical gene accessions in the same MEGARes **Group** (a common database-redundancy artifact), the hit is collapsed to one gene (`group_aware = "Y"`) rather than double-counted. Mates mapping to genuinely different Groups are counted once to each.
+   - Query coverage is now "edge-aware" (`edge_aware_qcov = "Y"`): a read that aligns cleanly but runs off the end of a short gene isn't penalized for the overhanging portion. All three behaviors can be turned off (`count_mode = read_end`, `group_aware = "N"`, `edge_aware_qcov = "N"`).
+3. **Only primary alignments are counted** for the resistome (secondary/supplementary alignments are excluded by default).
+4. Changed default AMR gene fraction `--threshold` to `0`, and added query-coverage / gene-fraction filters to the analyzer (`--min_gene_fraction`, `--min_query_coverage`, both on a 0–1 proportion scale). We recommend running statistical analysis of count matrices after aggregating to the "Group" level to account for possible false-positive calls of individual gene accessions.
+5. **Deduplication: alignment deduplication is no longer run by default — we now recommend read deduplication instead**, particularly when analyzing target-enriched data.
+   - **Read deduplication** (`read_dedup = "Y"`, Clumpify, applied after QC trimming) more directly addresses PCR duplication by collapsing reads that are actual sequence duplicates.
+   - **Alignment deduplication** (`deduped`) produced a larger overall reduction in read numbers, but that reduction included reads that were **not** true duplicates — reads could be collapsed based on alignment coordinates/length rather than being genuine PCR duplicates. Because of this over-collapsing, it is no longer the default recommendation.
+   - Alignment deduplication is still available for comparison via `deduped = "Y"`; read deduplication is the recommended approach.
+6. Added single-end and merged-read analysis.
+7. Changed defaults to skip rarefaction analysis, but default to running SNP confirmation.
+8. **Updated SNP confirmation tool (on a separate branch).** The SNP verifier now adjusts counts by the *proportion of reads that actually carry the confirmed SNP*: it computes (reads with the SNP / reads covering the SNP position) and multiplies by the gene's count, rather than substituting a raw resistant-read count. Genes that require SNP confirmation but have no entry in the SNP database are now set to zero (previously they passed through unconfirmed). The tool has also been updated to run cleanly under **Nextflow DSL2 syntax**.
+9. **New coverage-threshold sweep workflow (`bam_coverage_sweep`).** Runs a set of pre-aligned BAMs across a grid of gene-fraction and query-coverage thresholds, then produces combined matrices and drop-off plots showing how the resistome (genes, classes, mechanisms, groups) shrinks as thresholds tighten — a way to choose sensible cutoffs and see each sample's sensitivity to them. See the [coverage sweep tutorial](docs/Coverage_sweep_tutorial.md).
+
 
 [Additional analysis tips here.](docs/Analysis_recommendations.md)
 
@@ -33,21 +46,21 @@ More Information
 ----------------
 
 - [Getting Started](docs/GettingStarted.md)
-- [Installation](https://github.com/Microbial-Ecology-Group/AMRplusplus/blob/master/docs/installation.md)
-- [Usage](https://github.com/Microbial-Ecology-Group/AMRplusplus/blob/master/docs/usage.md)
+- [Installation](docs/installation.md)
+- [Usage](docs/usage.md)
   - [Choosing the right pipeline](docs/choosing_pipeline.md)
   - [Analysis recommendations](docs/Analysis_recommendations.md)
   - [Paired-end analysis step-by-step](docs/Step_by_step_tutorial.md)
   - [Single-end analysis step-by-step](docs/SingleEnd_read_tutorial.md)
   - [Merged-read analysis step-by-step](docs/Merged_read_tutorial.md)
-- [Configuration](https://github.com/Microbial-Ecology-Group/AMRplusplus/blob/master/docs/configuration.md)
+  - [Coverage threshold sweep](docs/Coverage_sweep_tutorial.md)
+- [Configuration](docs/configuration.md)
   - [Tips for using SLURM](docs/Running_with_SLURM.md)
-- [Output](https://github.com/Microbial-Ecology-Group/AMRplusplus/blob/master/docs/output.md)
-- [Dependencies](https://github.com/Microbial-Ecology-Group/AMRplusplus/blob/master/docs/dependencies.md)
-- [Software Requirements](https://github.com/Microbial-Ecology-Group/AMRplusplus/blob/master/docs/requirements.md)
-- [Troubleshooting and FAQs](https://github.com/Microbial-Ecology-Group/AMRplusplus/blob/master/docs/FAQs.md)
-- [Details on AMR++ updates](https://github.com/Microbial-Ecology-Group/AMRplusplus/blob/master/docs/update_details.md)
-- [Contact](https://github.com/Microbial-Ecology-Group/AMRplusplus/blob/master/docs/contact.md)
+- [Output](docs/output.md)
+- [Dependencies](docs/dependencies.md)
+- [Troubleshooting and FAQs](FAQs.md)
+- [Details on AMR++ updates](docs/CHANGELOG.md)
+- [Contact](docs/contact.md)
 
 
 

--- a/bin/alignment_analyzer.py
+++ b/bin/alignment_analyzer.py
@@ -20,7 +20,7 @@ CHANGES IN THIS VERSION
    alongside the existing breadth-based coverage_fraction, plus a "meg_id"
    join column (gene_accession split on the first '|').
 
-4. NEW — retained-read tracking. Every run now reports, and optionally writes
+4. retained-read tracking. Every run now reports, and optionally writes
    to a small stats file, how many primary alignments existed BEFORE any
    --min-mapq/--min-query-coverage filtering vs how many passed (and the %
    retained). Previously this number wasn't tracked or surfaced anywhere —
@@ -393,12 +393,15 @@ def get_passing_genes(gene_fractions: Dict[str, float], min_fraction: float) -> 
     return {gene for gene, frac in gene_fractions.items() if frac >= min_fraction}
 
 
-def format_gene_alignment_field(gene_mapq_qcov: Dict[str, List[Tuple[int, float]]]) -> str:
+def format_gene_alignment_field(gene_mapq_qcov: Dict[str, List[Tuple[int, float, float]]]) -> str:
     if not gene_mapq_qcov:
         return "-"
     parts = []
     for gene in sorted(gene_mapq_qcov.keys()):
-        entry_str = ",".join(f"{mq}:{qc:.1f}" for mq, qc in gene_mapq_qcov[gene])
+        # entries are (mapq, qcov_pct, match_qcov_pct); show mapq:qcov:match_qcov
+        entry_str = ",".join(
+            f"{mq}:{qc:.1f}:{mqc:.1f}" for mq, qc, mqc in gene_mapq_qcov[gene]
+        )
         parts.append(f"{gene}({entry_str})")
     return "/".join(parts)
 
@@ -440,7 +443,7 @@ def summarize_genes_read_end(per_read: Dict[str, Dict[str, Any]], passing_genes:
                 continue
         best_gene, best_mapq = None, -1
         for gene, entries in primary_genes.items():
-            max_mapq_for_gene = max(mq for mq, _qc in entries)
+            max_mapq_for_gene = max(mq for mq, _qc, _mqc in entries)
             if max_mapq_for_gene > best_mapq or (max_mapq_for_gene == best_mapq and (best_gene is None or gene < best_gene)):
                 best_gene, best_mapq = gene, max_mapq_for_gene
         if best_gene is not None:

--- a/bin/alignment_analyzer.py
+++ b/bin/alignment_analyzer.py
@@ -44,6 +44,7 @@ CHANGES IN THIS VERSION
 
 import argparse
 import os
+import re
 import statistics
 import sys
 from collections import Counter, defaultdict
@@ -85,18 +86,55 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--sample-id", default=None,
                         help="Sample ID column header in the gene summary; inferred from filename if omitted.")
     parser.add_argument(
-        "--count-mode", choices=["read_end", "alignment"], default="read_end",
+        "--count-mode", choices=["read_end", "alignment", "fragment"], default="fragment",
         help=(
             "'read_end' (default): each read-end contributes exactly 1 count to "
             "its best primary alignment gene (highest MAPQ). "
-            "'alignment': each individual passing alignment record contributes 1 count."
+            "'alignment': each individual passing alignment record contributes 1 count. "
+            "'fragment': mates are resolved together into one physical fragment "
+            "(base_read_id groups R1/R2 and strips FLASH suffixes), so a paired-end "
+            "fragment and a FLASH-merged fragment are weighted IDENTICALLY (1 hit each). "
+            "This is the counting unit used by coverage_threshold_sweep.py and fixes the "
+            "old Combined-BAM problem where unmerged (paired) reads were counted twice "
+            "relative to merged reads."
         ),
+    )
+    parser.add_argument(
+        "--group-aware", dest="group_aware", action="store_true", default=True,
+        help=(
+            "(DEFAULT ON) Only meaningful with --count-mode fragment. When two mates of a "
+            "fragment disagree on gene_accession, check whether the two accessions share the "
+            "same MEGARes Group before treating it as real discordance. Same-Group disagreement "
+            "(the multi-mapping/redundant-accession artifact from BWA tie-breaking among "
+            "near-identical DB entries) is collapsed to ONE hit for the higher-match_qcov mate "
+            "rather than double-counted. Group is parsed directly from the MEGARes "
+            "pipe-delimited reference name (no annotation file needed). "
+            "Use --no-group-aware to disable."
+        ),
+    )
+    parser.add_argument(
+        "--no-group-aware", dest="group_aware", action="store_false",
+        help="Disable group-aware fragment resolution (mate disagreements count to each gene).",
     )
     parser.add_argument("--include-supplementary", action="store_true", default=False,
                         help="Include supplementary alignments in counts (and, by default, in breadth coverage).")
     parser.add_argument(
         "--min-gene-fraction", type=float, default=0.0,
         help="Minimum fraction of gene length covered by passing alignments for that gene to count (0.0-1.0).",
+    )
+    parser.add_argument("--edge-aware-qcov", dest="edge_aware_qcov", action="store_true", default=True,
+        help=(
+            "(DEFAULT ON) Compute query-coverage against a coverage-anchored read length: "
+            "reconstruct full read length from the CIGAR (soft AND hard clips) so "
+            "the aligner's clip choice doesn't change qcov, and discount clip bases "
+            "that overhang the reference edge (a read running off the end of a short "
+            "gene is not penalized for the overhanging portion). Only affects the "
+            "qcov (read-axis) metric; gene breadth/fraction is unaffected. "
+            "Use --no-edge-aware-qcov to disable."
+        ),
+    )
+    parser.add_argument("--no-edge-aware-qcov", dest="edge_aware_qcov", action="store_false",
+        help="Disable edge-aware qcov (use raw read.query_length as the denominator).",
     )
     parser.add_argument("--cigar-aware-coverage", action="store_true", default=False,
                         help="Use CIGAR-aware breadth coverage (excludes deletions/skips). Recommended.")
@@ -181,6 +219,49 @@ def get_covered_positions_simple(read: pysam.AlignedSegment) -> Set[int]:
     return set(range(read.reference_start, read.reference_end))
 
 
+def edge_aware_query_length(read: pysam.AlignedSegment, ref_length: int) -> int:
+    """
+    Coverage-anchored read length for query-coverage (qcov).
+
+    Two problems this fixes vs a raw read.query_length:
+      1. SOFT vs HARD clip asymmetry. read.query_length includes soft-clipped
+         bases but NOT hard-clipped ones, so the same physical alignment scores a
+         different qcov depending purely on whether the aligner soft- or
+         hard-clipped. We reconstruct the full physical length from the CIGAR
+         (aligned + BOTH clip types, ops 4=S and 5=H) so the choice is irrelevant.
+      2. REFERENCE-EDGE OVERHANG. When a read runs past the end of a short gene,
+         the overhanging bases COULD NOT have aligned (the reference simply ended).
+         Penalizing qcov for them is wrong. We subtract the portion of each
+         terminal clip that falls outside [0, ref_length) -- i.e. the bases with no
+         reference position to map to -- from the denominator.
+
+    Returns the number of read bases that actually HAD A CHANCE to align. qcov is
+    then aln_len / this, so a read fully explained by the gene that merely runs off
+    the gene's edge scores ~100% regardless of soft/hard clipping.
+
+    Never returns less than query_alignment_length (qcov <= 100%).
+    """
+    if read.cigartuples is None:
+        return read.query_alignment_length or 0
+
+    aln_len = read.query_alignment_length or 0
+    ops = read.cigartuples
+
+    lead_clip = ops[0][1] if ops and ops[0][0] in (4, 5) else 0
+    trail_clip = ops[-1][1] if len(ops) > 1 and ops[-1][0] in (4, 5) else 0
+
+    total_physical = aln_len + lead_clip + trail_clip
+
+    # bases of each terminal clip that overhang the reference edge (couldn't align)
+    ref_start = read.reference_start if read.reference_start is not None else 0
+    ref_end = read.reference_end if read.reference_end is not None else 0
+    overhang_5 = max(0, lead_clip - ref_start)
+    overhang_3 = max(0, trail_clip - (ref_length - ref_end)) if ref_length else 0
+
+    eff = total_physical - overhang_5 - overhang_3
+    return max(eff, aln_len)
+
+
 def aggregate_per_read_and_alignment_counts(
     aln: pysam.AlignmentFile,
     min_mapq: int = 0,
@@ -188,6 +269,8 @@ def aggregate_per_read_and_alignment_counts(
     include_supplementary: bool = False,
     cigar_aware_coverage: bool = False,
     coverage_ignore_filters: bool = False,
+    edge_aware_qcov: bool = False,
+    ref_lengths: Optional[Dict[str, int]] = None,
 ) -> Tuple[Dict[str, Dict[str, Any]], Counter, Counter, Dict[str, Set[int]], Dict[str, List[float]], int, int]:
     """
     Returns (per_read, align_counts_with_supp, align_counts_no_supp,
@@ -227,9 +310,23 @@ def aggregate_per_read_and_alignment_counts(
 
         ref_name = aln.get_reference_name(read.reference_id)
 
-        qlen = read.query_length or 0
         aln_len = read.query_alignment_length or 0
+        if edge_aware_qcov:
+            ref_len = (ref_lengths or {}).get(ref_name, 0)
+            qlen = edge_aware_query_length(read, ref_len)
+        else:
+            qlen = read.query_length or 0
         qcov_pct = round(aln_len / qlen * 100.0, 2) if qlen else 0.0
+
+        # match_qcov_pct = fraction of the WHOLE read explained by genuine matches
+        # (aligned bases minus edit distance), over the same (edge-aware if enabled)
+        # read-length denominator as qcov. Used as the group-aware tie-break metric.
+        # Reads with no NM tag fall back to qcov_pct so they still tie-break sensibly.
+        try:
+            nm = read.get_tag('NM')
+            match_qcov_pct = round((aln_len - nm) / qlen * 100.0, 2) if qlen else 0.0
+        except KeyError:
+            match_qcov_pct = qcov_pct
 
         passes_mapq = read.mapping_quality >= min_mapq
         passes_qcov = qcov_pct >= min_qcov_pct
@@ -244,7 +341,7 @@ def aggregate_per_read_and_alignment_counts(
 
         if read.is_secondary:
             gene_map = per_read[rid]["secondary_genes"]
-            gene_map.setdefault(ref_name, []).append((read.mapping_quality, qcov_pct))
+            gene_map.setdefault(ref_name, []).append((read.mapping_quality, qcov_pct, match_qcov_pct))
             if passes_filter:
                 align_counts_with_supp[ref_name] += 1
                 align_counts_no_supp[ref_name] += 1
@@ -252,7 +349,7 @@ def aggregate_per_read_and_alignment_counts(
 
         if read.is_supplementary:
             gene_map = per_read[rid]["supplementary_genes"]
-            gene_map.setdefault(ref_name, []).append((read.mapping_quality, qcov_pct))
+            gene_map.setdefault(ref_name, []).append((read.mapping_quality, qcov_pct, match_qcov_pct))
             if passes_filter:
                 align_counts_with_supp[ref_name] += 1
             continue
@@ -262,7 +359,7 @@ def aggregate_per_read_and_alignment_counts(
         if passes_filter:
             total_primary_passing += 1
             gene_map = per_read[rid]["primary_genes"]
-            gene_map.setdefault(ref_name, []).append((read.mapping_quality, qcov_pct))
+            gene_map.setdefault(ref_name, []).append((read.mapping_quality, qcov_pct, match_qcov_pct))
             align_counts_with_supp[ref_name] += 1
             align_counts_no_supp[ref_name] += 1
             gene_query_coverages[ref_name].append(qcov_pct)
@@ -418,6 +515,115 @@ def write_stats_output(
         out.write(f"pct_genes_passing_of_baseline\t{pct_genes_passing if pct_genes_passing is not None else 'NA'}\n")
 
 
+# ── Fragment-level counting (mirrors coverage_threshold_sweep.resolve_fragment_hits) ──
+
+# Same regexes coverage_threshold_sweep.py uses, so fragment identity is identical
+# between the two tools: strip FLASH suffixes and a trailing /1 /2 .1 .2.
+_RE_FLASH = re.compile(r'\.(extendedFrags|notCombined)[^/]*$')
+_RE_PAIR  = re.compile(r'[/\.][12]$')
+
+
+def get_base_read_id(read_id: str) -> str:
+    """Collapse a read-end id to its physical-fragment id (matches the sweep)."""
+    base = _RE_FLASH.sub('', read_id)
+    return _RE_PAIR.sub('', base)
+
+
+def parse_megares_group(ref_name: str) -> str:
+    """
+    Extract the Group field from a MEGARes pipe-delimited accession.
+    Header layout: MEG_ID|Type|Class|Mechanism|Group[|SNP]. Returns the Group
+    (5th field, index 4) or '' if the name isn't in the expected format.
+    Mirrors coverage_threshold_sweep.parse_gene_reference so both tools derive
+    Group the same way — directly from the reference name, no annotation CSV needed.
+    """
+    parts = ref_name.split('|')
+    return parts[4] if len(parts) >= 5 else ''
+
+
+def summarize_genes_fragment(
+    per_read: Dict[str, Dict[str, Any]],
+    passing_genes: Optional[Set[str]] = None,
+    group_aware: bool = False,
+) -> Tuple[Counter, Dict[str, int]]:
+    """
+    Fragment-level counting. First reduce each read-end to a single best gene,
+    then group those best-calls by base_read_id and resolve mates together.
+
+    "Best gene per read-end" and the group-aware disagreement tie-break both use
+    match_qcov_pct (fraction of the read explained by genuine matches), consistent
+    with coverage_threshold_sweep.resolve_fragment_hits. Ties broken alphabetically.
+
+      both mates same gene            -> 1 hit
+      only one mate present           -> 1 hit
+      mates disagree, group_aware off -> 1 hit to EACH gene (legacy behaviour)
+      mates disagree, group_aware on:
+        same Group, different accession -> 1 hit to the higher-match_qcov mate
+                                           (redundant-DB-entry artifact collapsed)
+        different Groups                -> 1 hit to EACH gene (real cross-mechanism
+                                           fragment; both mechanisms counted)
+
+    Returns (hits, diagnostics).
+    """
+    # Step 1: best gene per read-end, scored by match_qcov (3rd tuple element)
+    frag_groups: Dict[str, List[Tuple[str, float]]] = defaultdict(list)
+    for rid, info in per_read.items():
+        primary_genes = info["primary_genes"]
+        if not primary_genes:
+            continue
+        if passing_genes is not None:
+            primary_genes = {g: v for g, v in primary_genes.items() if g in passing_genes}
+            if not primary_genes:
+                continue
+        best_gene, best_score = None, -1.0
+        for gene, entries in primary_genes.items():
+            # entries are (mapq, qcov_pct, match_qcov_pct); score on match_qcov
+            max_mqcov = max(mqc for _mq, _qc, mqc in entries)
+            if max_mqcov > best_score or (max_mqcov == best_score and (best_gene is None or gene < best_gene)):
+                best_gene, best_score = gene, max_mqcov
+        if best_gene is not None:
+            frag_groups[get_base_read_id(rid)].append((best_gene, best_score))
+
+    # Step 2: resolve mates within each fragment
+    hits: Counter = Counter()
+    diagnostics: Dict[str, int] = defaultdict(int)
+
+    for base_id, entries in frag_groups.items():
+        if len(entries) == 1:
+            hits[entries[0][0]] += 1
+            diagnostics['one_mate_only'] += 1
+        elif len(entries) == 2:
+            (g1, s1), (g2, s2) = entries
+            if g1 == g2:
+                hits[g1] += 1
+                diagnostics['same_gene'] += 1
+            elif group_aware:
+                grp1, grp2 = parse_megares_group(g1), parse_megares_group(g2)
+                if grp1 and grp1 == grp2:
+                    # Same Group, different accession = redundant-DB-entry artifact.
+                    # Collapse to ONE hit for the higher-match_qcov mate (s1/s2);
+                    # alphabetical on exact tie.
+                    winner = g1 if (s1 > s2 or (s1 == s2 and g1 < g2)) else g2
+                    hits[winner] += 1
+                    diagnostics['same_group_diff_gene'] += 1
+                else:
+                    # Genuinely different Groups = a real cross-mechanism fragment.
+                    # Count ONE hit to EACH gene (both mechanisms are evidenced).
+                    hits[g1] += 1
+                    hits[g2] += 1
+                    diagnostics['cross_group_both_counted'] += 1
+            else:
+                hits[g1] += 1
+                hits[g2] += 1
+                diagnostics['legacy_discordant_both_counted'] += 1
+        else:
+            for g, _ in entries:
+                hits[g] += 1
+            diagnostics['unexpected_multi_mate'] += 1
+
+    return hits, diagnostics
+
+
 def main():
     args = parse_args()
     sample_id = args.sample_id if args.sample_id is not None else sample_id_from_path(args.input)
@@ -442,6 +648,8 @@ def main():
             include_supplementary=args.include_supplementary,
             cigar_aware_coverage=args.cigar_aware_coverage,
             coverage_ignore_filters=args.coverage_ignore_filters,
+            edge_aware_qcov=args.edge_aware_qcov,
+            ref_lengths=ref_lengths,
         )
     )
 
@@ -480,6 +688,12 @@ def main():
 
     if args.count_mode == "read_end":
         gene_counts = summarize_genes_read_end(per_read, passing_genes)
+    elif args.count_mode == "fragment":
+        gene_counts, frag_diag = summarize_genes_fragment(
+            per_read, passing_genes, group_aware=args.group_aware,
+        )
+        diag_str = ", ".join(f"{k}={v}" for k, v in sorted(frag_diag.items())) or "none"
+        print(f"[INFO] Fragment resolution diagnostics: {diag_str}")
     else:
         gene_counts = filter_align_counts(
             align_counts_with_supp if args.include_supplementary else align_counts_no_supp, passing_genes,

--- a/bin/alignment_analyzer.py
+++ b/bin/alignment_analyzer.py
@@ -1,11 +1,31 @@
 #!/usr/bin/env python3
-import argparse
-import os
-import sys
-from collections import Counter, defaultdict
-from typing import Dict, Any, Tuple, Set, Optional
+"""
+alignment_analyzer.py
+════════════════════════════════════════════════════════════════════════════════
 
-import pysam
+For each read (read-end) in a BAM/SAM, output the gene(s) it maps to via primary
+alignments and the MAPQ, plus a summary of counts per gene.
+
+CHANGES IN THIS VERSION
+────────────────────────
+1. --min-query-coverage flag (0.0-1.0, default 0.0). Read-level counterpart to
+   --min-gene-fraction: an alignment must cover this fraction of the READ's
+   length (aligned query bases / total read length) to be counted.
+
+2. Gene-length breadth coverage (--min-gene-fraction) now respects the same
+   quality filters as alignment counting by default. --coverage-ignore-filters
+   restores the old unfiltered behaviour.
+
+3. --coverage-output gains per-gene query-coverage depth stats (mean/median/n)
+   alongside the existing breadth-based coverage_fraction, plus a "meg_id"
+   join column (gene_accession split on the first '|').
+
+4. NEW — retained-read tracking. Every run now reports, and optionally writes
+   to a small stats file, how many primary alignments existed BEFORE any
+   --min-mapq/--min-query-coverage filtering vs how many passed (and the %
+   retained). Previously this number wasn't tracked or surfaced anywhere —
+   the script silently filtered without reporting what fraction of the
+   original classified reads survived.
 
 ## Example command
 #    python3 alignment_analyzer.py \
@@ -16,9 +36,21 @@ import pysam
 #        --min-mapq 0 \
 #        --count-mode alignment \
 #        --min-gene-fraction 0.8 \
+#        --min-query-coverage 0.8 \
 #        --include-supplementary \
 #        --cigar-aware-coverage \
 #        --coverage-output "counts/${sample_id}_coverage_stats.tsv"
+"""
+
+import argparse
+import os
+import statistics
+import sys
+from collections import Counter, defaultdict
+from typing import Dict, Any, Tuple, Set, Optional, List
+
+import pysam
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -27,122 +59,77 @@ def parse_args() -> argparse.Namespace:
             "via primary alignments and the MAPQ, plus a summary of counts per gene."
         )
     )
+    parser.add_argument("-i", "--input", required=True, help="Input alignment file (.bam or .sam)")
+    parser.add_argument("-r", "--read-output", required=True, help="Output TSV with per-read information")
+    parser.add_argument("-g", "--gene-summary", required=True, help="Output TSV with per-gene summary counts")
+    parser.add_argument("--min-mapq", type=int, default=0,
+                        help="Minimum mapping quality for an alignment to be considered (default: 0).")
     parser.add_argument(
-        "-i", "--input",
-        required=True,
-        help="Input alignment file (.bam or .sam)"
-    )
-    parser.add_argument(
-        "-r", "--read-output",
-        required=True,
-        help="Output TSV with per-read information"
-    )
-    parser.add_argument(
-        "-g", "--gene-summary",
-        required=True,
-        help="Output TSV with per-gene summary counts"
-    )
-    parser.add_argument(
-        "--min-mapq",
-        type=int,
-        default=0,
+        "--min-query-coverage", type=float, default=0.0,
         help=(
-            "Minimum mapping quality for an alignment to be considered "
-            "(default: 0)."
+            "Minimum fraction of the READ that must be covered by the alignment "
+            "(aligned query bases / total read length, 0.0-1.0, default: 0.0). "
+            "Read-level counterpart to --min-gene-fraction: filters out "
+            "alignments built from only a short partial overlap of the read."
         ),
     )
     parser.add_argument(
-        "--sample-id",
-        default=None,
+        "--coverage-ignore-filters", action="store_true", default=False,
         help=(
-            "Sample ID to use as the column header in the gene summary. "
-            "If not provided, inferred from the BAM/SAM filename."
+            "Compute gene-length breadth coverage from ALL alignments, ignoring "
+            "--min-mapq/--min-query-coverage/--include-supplementary. Restores "
+            "pre-this-version behaviour. By default breadth now only counts "
+            "alignments that pass the same filters used for counting."
         ),
     )
+    parser.add_argument("--sample-id", default=None,
+                        help="Sample ID column header in the gene summary; inferred from filename if omitted.")
     parser.add_argument(
-        "--count-mode",
-        choices=["read_end", "alignment"],
-        default="read_end",
+        "--count-mode", choices=["read_end", "alignment"], default="read_end",
         help=(
-            "How to summarize counts per gene. "
-            "'read_end' (default): each read-end contributes exactly 1 count "
-            "to its best primary alignment gene (highest MAPQ). "
-            "'alignment': each individual alignment record that passes filters "
-            "contributes 1 count (primary + secondary, optionally + supplementary)."
+            "'read_end' (default): each read-end contributes exactly 1 count to "
+            "its best primary alignment gene (highest MAPQ). "
+            "'alignment': each individual passing alignment record contributes 1 count."
         ),
     )
+    parser.add_argument("--include-supplementary", action="store_true", default=False,
+                        help="Include supplementary alignments in counts (and, by default, in breadth coverage).")
     parser.add_argument(
-        "--include-supplementary",
-        action="store_true",
-        default=False,
-        help=(
-            "Include supplementary alignments in counts. "
-            "By default, only primary and secondary alignments are counted. "
-            "This flag adds supplementary (chimeric/split) alignments to the counts."
-        ),
+        "--min-gene-fraction", type=float, default=0.0,
+        help="Minimum fraction of gene length covered by passing alignments for that gene to count (0.0-1.0).",
     )
+    parser.add_argument("--cigar-aware-coverage", action="store_true", default=False,
+                        help="Use CIGAR-aware breadth coverage (excludes deletions/skips). Recommended.")
+    parser.add_argument("--coverage-output", default=None,
+                        help="Optional output TSV with per-gene breadth AND query-coverage depth statistics.")
     parser.add_argument(
-        "--min-gene-fraction",
-        type=float,
-        default=0.0,
+        "--stats-output", default=None,
         help=(
-            "Minimum fraction of gene length that must be covered by at least one "
-            "alignment for that gene to be counted (0.0-1.0, default: 0.0 = no filter). "
-            "E.g., 0.8 means 80%% of the gene must be covered. "
-            "Applies to both read_end and alignment count modes."
+            "Optional output TSV with overall retained-read statistics: total "
+            "primary alignments seen before filtering, how many passed "
+            "--min-mapq/--min-query-coverage, and the percent retained. "
+            "If omitted but --coverage-output is set, defaults to "
+            "'<coverage-output>.stats.tsv'."
         ),
     )
-    parser.add_argument(
-        "--cigar-aware-coverage",
-        action="store_true",
-        default=False,
-        help=(
-            "Use CIGAR-aware coverage calculation. "
-            "Only counts positions with M/=/X operations as covered. "
-            "Excludes deletions (D) and skipped regions (N) from coverage. "
-            "More accurate but slightly slower. Recommended for RNA-seq or "
-            "alignments with large indels."
-        ),
-    )
-    parser.add_argument(
-        "--coverage-output",
-        default=None,
-        help=(
-            "Optional output TSV with per-gene coverage statistics. "
-            "If not provided, coverage stats are not written."
-        ),
-    )
-    parser.add_argument(
-        "--force",
-        action="store_true",
-        default=False,
-        help=(
-            "Force overwrite of existing output files. "
-            "By default, if output files exist, the sample is skipped."
-        ),
-    )
+    parser.add_argument("--force", action="store_true", default=False, help="Force overwrite of existing output files.")
     return parser.parse_args()
 
 
 def check_outputs_exist(args: argparse.Namespace) -> bool:
-    """Check if all output files already exist."""
     outputs_to_check = [args.read_output, args.gene_summary]
     if args.coverage_output:
         outputs_to_check.append(args.coverage_output)
-    
     return all(os.path.exists(f) for f in outputs_to_check)
 
 
 def guess_mode(path: str) -> str:
-    if path.lower().endswith(".bam"):
-        return "rb"
-    return "r"
+    return "rb" if path.lower().endswith(".bam") else "r"
 
 
 def open_alignment(path: str) -> pysam.AlignmentFile:
-    mode = guess_mode(path)
     try:
-        return pysam.AlignmentFile(path, mode)
+        return pysam.AlignmentFile(path, guess_mode(path))
     except OSError as e:
         sys.exit(f"[ERROR] Could not open {path}: {e}")
 
@@ -165,423 +152,346 @@ def read_end_id(read: pysam.AlignedSegment) -> str:
     return qname
 
 
+def extract_meg_id(gene_accession: str) -> str:
+    """First pipe-delimited field, e.g. 'MEG_4288' from 'MEG_4288|Drugs|...'."""
+    return gene_accession.split('|')[0] if gene_accession else gene_accession
+
+
 def get_reference_lengths(aln: pysam.AlignmentFile) -> Dict[str, int]:
-    """Extract reference (gene) lengths from the BAM/SAM header."""
-    ref_lengths = {}
-    for ref_name, ref_length in zip(aln.references, aln.lengths):
-        ref_lengths[ref_name] = ref_length
-    return ref_lengths
+    return dict(zip(aln.references, aln.lengths))
 
 
 def get_covered_positions_cigar_aware(read: pysam.AlignedSegment) -> Set[int]:
-    """Get reference positions covered by the read using CIGAR operations.
-    
-    Only counts positions where the read actually aligns (M, =, X operations).
-    Does not count deletions (D) or skipped regions (N).
-    
-    CIGAR operations:
-        M (0): alignment match (can be sequence match or mismatch)
-        I (1): insertion to reference (consumes query, not reference)
-        D (2): deletion from reference (consumes reference, not query)
-        N (3): skipped region from reference (e.g., intron)
-        S (4): soft clipping (consumes query, not reference)
-        H (5): hard clipping (consumes neither)
-        P (6): padding (consumes neither)
-        = (7): sequence match (consumes both)
-        X (8): sequence mismatch (consumes both)
-    """
     covered = set()
-    
     if read.cigartuples is None:
         return covered
-    
     ref_pos = read.reference_start
-    
     for op, length in read.cigartuples:
-        if op in (0, 7, 8):  # M, =, X - actual alignment
-            for i in range(length):
-                covered.add(ref_pos + i)
+        if op in (0, 7, 8):
+            covered.update(range(ref_pos, ref_pos + length))
             ref_pos += length
-        elif op in (2, 3):  # D, N - consumes reference but not covered
+        elif op in (2, 3):
             ref_pos += length
-        # I (1), S (4), H (5), P (6) - don't consume reference
-    
     return covered
 
 
 def get_covered_positions_simple(read: pysam.AlignedSegment) -> Set[int]:
-    """Get reference positions covered using simple start-end range.
-    
-    Counts all positions between reference_start and reference_end as covered.
-    This includes deletions and skipped regions.
-    """
-    covered = set()
-    
-    if read.reference_start is not None and read.reference_end is not None:
-        for pos in range(read.reference_start, read.reference_end):
-            covered.add(pos)
-    
-    return covered
+    if read.reference_start is None or read.reference_end is None:
+        return set()
+    return set(range(read.reference_start, read.reference_end))
 
 
 def aggregate_per_read_and_alignment_counts(
     aln: pysam.AlignmentFile,
     min_mapq: int = 0,
+    min_query_coverage: float = 0.0,
     include_supplementary: bool = False,
     cigar_aware_coverage: bool = False,
-) -> Tuple[Dict[str, Dict[str, Any]], Counter, Counter, Dict[str, Set[int]]]:
-    """Iterate over all alignments and build:
-    - per_read: dict keyed by read_end_id with:
-        * 'primary_genes': dict gene -> list of MAPQs for primary alignments passing filter
-        * 'secondary_genes': dict gene -> list of MAPQs for secondary alignments
-        * 'supplementary_genes': dict gene -> list of MAPQs for supplementary alignments
-    - align_counts_with_supp: Counter(gene -> count) for primary + secondary + supplementary
-    - align_counts_no_supp: Counter(gene -> count) for primary + secondary only
-    - gene_coverage: dict gene -> set of covered positions
+    coverage_ignore_filters: bool = False,
+) -> Tuple[Dict[str, Dict[str, Any]], Counter, Counter, Dict[str, Set[int]], Dict[str, List[float]], int, int]:
+    """
+    Returns (per_read, align_counts_with_supp, align_counts_no_supp,
+              gene_coverage, gene_query_coverages,
+              total_primary_seen, total_primary_passing)
+
+    total_primary_seen     = every mapped PRIMARY alignment encountered,
+                              regardless of --min-mapq/--min-query-coverage.
+    total_primary_passing  = how many of those passed both filters and were
+                              actually counted as a classification.
+    These two let main() report exactly what fraction of originally-mapped
+    reads survive filtering — previously untracked.
     """
     per_read: Dict[str, Dict[str, Any]] = {}
     align_counts_with_supp: Counter = Counter()
     align_counts_no_supp: Counter = Counter()
     gene_coverage: Dict[str, Set[int]] = defaultdict(set)
+    gene_query_coverages: Dict[str, List[float]] = defaultdict(list)
+    total_primary_seen = 0
+    total_primary_passing = 0
 
-    # Choose coverage function
     get_covered_positions = (
-        get_covered_positions_cigar_aware if cigar_aware_coverage 
+        get_covered_positions_cigar_aware if cigar_aware_coverage
         else get_covered_positions_simple
     )
+
+    min_qcov_pct = min_query_coverage * 100.0
 
     for read in aln.fetch(until_eof=True):
         rid = read_end_id(read)
 
         if rid not in per_read:
-            per_read[rid] = {
-                "primary_genes": {},       # gene -> list[MAPQ]
-                "secondary_genes": {},     # gene -> list[MAPQ]
-                "supplementary_genes": {}, # gene -> list[MAPQ]
-            }
+            per_read[rid] = {"primary_genes": {}, "secondary_genes": {}, "supplementary_genes": {}}
 
-        # Skip unmapped alignments entirely
         if read.is_unmapped:
             continue
 
         ref_name = aln.get_reference_name(read.reference_id)
 
-        # Track coverage using chosen method
-        covered_positions = get_covered_positions(read)
-        gene_coverage[ref_name].update(covered_positions)
+        qlen = read.query_length or 0
+        aln_len = read.query_alignment_length or 0
+        qcov_pct = round(aln_len / qlen * 100.0, 2) if qlen else 0.0
 
-        # Check MAPQ threshold
         passes_mapq = read.mapping_quality >= min_mapq
+        passes_qcov = qcov_pct >= min_qcov_pct
+        passes_filter = passes_mapq and passes_qcov
 
-        # Secondary alignments
+        include_for_breadth = (
+            coverage_ignore_filters
+            or (passes_filter and (include_supplementary or not read.is_supplementary))
+        )
+        if include_for_breadth:
+            gene_coverage[ref_name].update(get_covered_positions(read))
+
         if read.is_secondary:
             gene_map = per_read[rid]["secondary_genes"]
-            gene_map.setdefault(ref_name, []).append(read.mapping_quality)
-            if passes_mapq:
+            gene_map.setdefault(ref_name, []).append((read.mapping_quality, qcov_pct))
+            if passes_filter:
                 align_counts_with_supp[ref_name] += 1
                 align_counts_no_supp[ref_name] += 1
             continue
 
-        # Supplementary alignments
         if read.is_supplementary:
             gene_map = per_read[rid]["supplementary_genes"]
-            gene_map.setdefault(ref_name, []).append(read.mapping_quality)
-            if passes_mapq:
+            gene_map.setdefault(ref_name, []).append((read.mapping_quality, qcov_pct))
+            if passes_filter:
                 align_counts_with_supp[ref_name] += 1
-                # NOT added to align_counts_no_supp
             continue
 
-        # Primary alignment
-        if passes_mapq:
+        # ── primary alignment ──────────────────────────────────────────────
+        total_primary_seen += 1
+        if passes_filter:
+            total_primary_passing += 1
             gene_map = per_read[rid]["primary_genes"]
-            gene_map.setdefault(ref_name, []).append(read.mapping_quality)
+            gene_map.setdefault(ref_name, []).append((read.mapping_quality, qcov_pct))
             align_counts_with_supp[ref_name] += 1
             align_counts_no_supp[ref_name] += 1
+            gene_query_coverages[ref_name].append(qcov_pct)
 
-    return per_read, align_counts_with_supp, align_counts_no_supp, gene_coverage
+    return (per_read, align_counts_with_supp, align_counts_no_supp,
+            gene_coverage, gene_query_coverages,
+            total_primary_seen, total_primary_passing)
 
 
-def calculate_gene_fractions(
-    gene_coverage: Dict[str, Set[int]],
-    ref_lengths: Dict[str, int]
-) -> Dict[str, float]:
-    """Calculate the fraction of each gene covered by alignments."""
-    gene_fractions = {}
-    for gene, covered_positions in gene_coverage.items():
-        gene_length = ref_lengths.get(gene, 0)
-        if gene_length > 0:
-            gene_fractions[gene] = len(covered_positions) / gene_length
+def calculate_gene_fractions(gene_coverage: Dict[str, Set[int]], ref_lengths: Dict[str, int]) -> Dict[str, float]:
+    fractions = {}
+    for gene, covered in gene_coverage.items():
+        length = ref_lengths.get(gene, 0)
+        fractions[gene] = (len(covered) / length) if length > 0 else 0.0
+    return fractions
+
+
+def calculate_query_coverage_stats(gene_query_coverages: Dict[str, List[float]]) -> Dict[str, Tuple[float, float, int]]:
+    stats = {}
+    for gene, values in gene_query_coverages.items():
+        if values:
+            stats[gene] = (round(statistics.mean(values), 2), round(statistics.median(values), 2), len(values))
         else:
-            gene_fractions[gene] = 0.0
-    return gene_fractions
+            stats[gene] = (0.0, 0.0, 0)
+    return stats
 
 
-def get_passing_genes(
-    gene_fractions: Dict[str, float],
-    min_fraction: float
-) -> Optional[Set[str]]:
-    """Return set of genes that meet the minimum coverage fraction threshold."""
+def get_passing_genes(gene_fractions: Dict[str, float], min_fraction: float) -> Optional[Set[str]]:
     if min_fraction <= 0.0:
-        return None  # No filtering
+        return None
     return {gene for gene, frac in gene_fractions.items() if frac >= min_fraction}
 
 
-def format_gene_mapq_field(gene_mapq_dict: Dict[str, list]) -> str:
-    """Format a gene -> [mapq, mapq, ...] dict as gene(mapq,mapq)/gene(mapq)"""
-    if not gene_mapq_dict:
+def format_gene_alignment_field(gene_mapq_qcov: Dict[str, List[Tuple[int, float]]]) -> str:
+    if not gene_mapq_qcov:
         return "-"
-    
     parts = []
-    for gene in sorted(gene_mapq_dict.keys()):
-        mqs = gene_mapq_dict[gene]
-        mq_str = ",".join(str(q) for q in mqs)
-        parts.append(f"{gene}({mq_str})")
+    for gene in sorted(gene_mapq_qcov.keys()):
+        entry_str = ",".join(f"{mq}:{qc:.1f}" for mq, qc in gene_mapq_qcov[gene])
+        parts.append(f"{gene}({entry_str})")
     return "/".join(parts)
 
 
-def count_alignments(gene_mapq_dict: Dict[str, list]) -> int:
-    """Count total number of alignments in a gene -> [mapq, ...] dict"""
-    return sum(len(mqs) for mqs in gene_mapq_dict.values())
+def count_alignments(gene_mapq_qcov: Dict[str, List[Tuple[int, float]]]) -> int:
+    return sum(len(entries) for entries in gene_mapq_qcov.values())
 
 
-def write_read_output(
-    per_read: Dict[str, Dict[str, Any]],
-    out_path: str,
-) -> None:
-    """Write per-read TSV with columns:
-        read_id
-        num_all_alignments
-        num_primary_secondary
-        num_primary_alignments
-        num_secondary_alignments
-        num_supplementary_alignments
-        primary_genes
-        secondary_genes
-        supplementary_genes
-    
-    Gene columns are formatted as: gene(mapq,mapq)/gene(mapq)
-    If no alignments in a category, the field is '-'.
-    """
+def write_read_output(per_read: Dict[str, Dict[str, Any]], out_path: str) -> None:
     with open(out_path, "w") as out:
         out.write(
-            "read_id\t"
-            "num_all_alignments\t"
-            "num_primary_secondary\t"
-            "num_primary_alignments\t"
-            "num_secondary_alignments\t"
-            "num_supplementary_alignments\t"
-            "primary_genes\t"
-            "secondary_genes\t"
-            "supplementary_genes\n"
+            "read_id\tnum_all_alignments\tnum_primary_secondary\t"
+            "num_primary_alignments\tnum_secondary_alignments\tnum_supplementary_alignments\t"
+            "primary_genes\tsecondary_genes\tsupplementary_genes\n"
         )
-
         for rid, info in per_read.items():
-            primary_genes = info["primary_genes"]
-            secondary_genes = info["secondary_genes"]
-            supplementary_genes = info["supplementary_genes"]
-
-            num_primary = count_alignments(primary_genes)
-            num_secondary = count_alignments(secondary_genes)
-            num_supplementary = count_alignments(supplementary_genes)
-            num_primary_secondary = num_primary + num_secondary
-            num_all = num_primary + num_secondary + num_supplementary
-
-            primary_field = format_gene_mapq_field(primary_genes)
-            secondary_field = format_gene_mapq_field(secondary_genes)
-            supplementary_field = format_gene_mapq_field(supplementary_genes)
-
+            primary, secondary, supplementary = info["primary_genes"], info["secondary_genes"], info["supplementary_genes"]
+            num_primary, num_secondary, num_supplementary = (
+                count_alignments(primary), count_alignments(secondary), count_alignments(supplementary)
+            )
             out.write(
-                f"{rid}\t"
-                f"{num_all}\t"
-                f"{num_primary_secondary}\t"
-                f"{num_primary}\t"
-                f"{num_secondary}\t"
-                f"{num_supplementary}\t"
-                f"{primary_field}\t"
-                f"{secondary_field}\t"
-                f"{supplementary_field}\n"
+                f"{rid}\t{num_primary + num_secondary + num_supplementary}\t"
+                f"{num_primary + num_secondary}\t{num_primary}\t{num_secondary}\t{num_supplementary}\t"
+                f"{format_gene_alignment_field(primary)}\t"
+                f"{format_gene_alignment_field(secondary)}\t"
+                f"{format_gene_alignment_field(supplementary)}\n"
             )
 
 
-def summarize_genes_read_end(
-    per_read: Dict[str, Dict[str, Any]],
-    passing_genes: Optional[Set[str]] = None
-) -> Counter:
-    """Build a Counter of how many read-ends are classified to each gene.
-    
-    For each read-end:
-      - If it has one or more primary alignments, pick the one with the highest MAPQ
-      - That gene gets +1 count
-      - If there's a tie, pick alphabetically first gene (deterministic)
-      - Each read-end contributes AT MOST 1 count total
-      - If passing_genes is provided, only count genes in that set
-    
-    Result: Counter(gene_accession -> count_of_read_ends)
-    """
+def summarize_genes_read_end(per_read: Dict[str, Dict[str, Any]], passing_genes: Optional[Set[str]] = None) -> Counter:
     counts = Counter()
-
     for info in per_read.values():
-        primary_genes = info["primary_genes"]  # dict: gene -> [mapq, ...]
-
+        primary_genes = info["primary_genes"]
         if not primary_genes:
             continue
-
-        # Filter to only passing genes if threshold is set
         if passing_genes is not None:
-            primary_genes = {g: m for g, m in primary_genes.items() if g in passing_genes}
+            primary_genes = {g: v for g, v in primary_genes.items() if g in passing_genes}
             if not primary_genes:
                 continue
-
-        # Find the best primary alignment: highest MAPQ, then alphabetically first gene
-        best_gene = None
-        best_mapq = -1
-
-        for gene, mapqs in primary_genes.items():
-            max_mapq_for_gene = max(mapqs)
+        best_gene, best_mapq = None, -1
+        for gene, entries in primary_genes.items():
+            max_mapq_for_gene = max(mq for mq, _qc in entries)
             if max_mapq_for_gene > best_mapq or (max_mapq_for_gene == best_mapq and (best_gene is None or gene < best_gene)):
-                best_gene = gene
-                best_mapq = max_mapq_for_gene
-
+                best_gene, best_mapq = gene, max_mapq_for_gene
         if best_gene is not None:
             counts[best_gene] += 1
-
     return counts
 
 
-def filter_align_counts(
-    align_counts: Counter,
-    passing_genes: Optional[Set[str]] = None
-) -> Counter:
-    """Filter alignment counts to only include passing genes."""
+def filter_align_counts(align_counts: Counter, passing_genes: Optional[Set[str]] = None) -> Counter:
     if passing_genes is None:
         return align_counts
     return Counter({g: c for g, c in align_counts.items() if g in passing_genes})
 
 
-def write_gene_summary(
-    gene_counts: Counter,
-    sample_id: str,
-    out_path: str,
-) -> None:
+def write_gene_summary(gene_counts: Counter, sample_id: str, out_path: str) -> None:
     with open(out_path, "w") as out:
-        out.write(f"gene_accession\t{sample_id}\n")
+        out.write(f"gene_accession\tmeg_id\t{sample_id}\n")
         for gene, count in sorted(gene_counts.items()):
-            out.write(f"{gene}\t{count}\n")
+            out.write(f"{gene}\t{extract_meg_id(gene)}\t{count}\n")
 
 
 def write_coverage_output(
-    gene_fractions: Dict[str, float],
-    ref_lengths: Dict[str, int],
-    gene_coverage: Dict[str, Set[int]],
-    passing_genes: Optional[Set[str]],
-    min_fraction: float,
-    out_path: str,
+    gene_fractions: Dict[str, float], ref_lengths: Dict[str, int], gene_coverage: Dict[str, Set[int]],
+    query_coverage_stats: Dict[str, Tuple[float, float, int]], passing_genes: Optional[Set[str]],
+    min_fraction: float, out_path: str,
 ) -> None:
-    """Write per-gene coverage statistics."""
     with open(out_path, "w") as out:
         out.write(
-            "gene_accession\t"
-            "gene_length\t"
-            "covered_bases\t"
-            "coverage_fraction\t"
-            "coverage_percent\t"
-            "passes_threshold\n"
+            "gene_accession\tmeg_id\tgene_length\tcovered_bases\t"
+            "coverage_fraction\tcoverage_percent\tpasses_threshold\t"
+            "n_primary_alignments\tmean_query_coverage_pct\tmedian_query_coverage_pct\n"
         )
-        
-        # Include all genes that have any coverage or are in reference
-        all_genes = set(ref_lengths.keys()) | set(gene_coverage.keys())
-        
+        all_genes = set(ref_lengths.keys()) | set(gene_coverage.keys()) | set(query_coverage_stats.keys())
         for gene in sorted(all_genes):
             gene_length = ref_lengths.get(gene, 0)
             covered_bases = len(gene_coverage.get(gene, set()))
             fraction = gene_fractions.get(gene, 0.0)
             percent = fraction * 100
             passes = "yes" if (passing_genes is None or gene in passing_genes) else "no"
-            
+            mean_qc, median_qc, n_aln = query_coverage_stats.get(gene, (0.0, 0.0, 0))
             out.write(
-                f"{gene}\t"
-                f"{gene_length}\t"
-                f"{covered_bases}\t"
-                f"{fraction:.4f}\t"
-                f"{percent:.2f}\t"
-                f"{passes}\n"
+                f"{gene}\t{extract_meg_id(gene)}\t{gene_length}\t{covered_bases}\t"
+                f"{fraction:.4f}\t{percent:.2f}\t{passes}\t{n_aln}\t{mean_qc:.2f}\t{median_qc:.2f}\n"
             )
+
+
+def write_stats_output(
+    out_path: str, sample_id: str, total_primary_seen: int, total_primary_passing: int,
+    min_mapq: int, min_query_coverage: float, n_genes_baseline: int, n_genes_passing: Optional[int],
+    min_gene_fraction: float,
+) -> None:
+    """
+    Overall retained-read diagnostic — answers "how many reads were included
+    as classifications, and what % of the total classified reads survived
+    filtering?" which was previously not tracked anywhere in this script.
+    """
+    pct_retained = round(total_primary_passing / total_primary_seen * 100, 2) if total_primary_seen else 0.0
+    pct_genes_passing = (
+        round(n_genes_passing / n_genes_baseline * 100, 2)
+        if (n_genes_passing is not None and n_genes_baseline) else None
+    )
+    with open(out_path, "w") as out:
+        out.write("metric\tvalue\n")
+        out.write(f"sample_id\t{sample_id}\n")
+        out.write(f"min_mapq\t{min_mapq}\n")
+        out.write(f"min_query_coverage\t{min_query_coverage}\n")
+        out.write(f"min_gene_fraction\t{min_gene_fraction}\n")
+        out.write(f"total_primary_alignments_seen\t{total_primary_seen}\n")
+        out.write(f"total_primary_alignments_passing\t{total_primary_passing}\n")
+        out.write(f"pct_primary_alignments_retained\t{pct_retained}\n")
+        out.write(f"n_genes_detected_baseline\t{n_genes_baseline}\n")
+        out.write(f"n_genes_passing_fraction_threshold\t{n_genes_passing if n_genes_passing is not None else 'NA'}\n")
+        out.write(f"pct_genes_passing_of_baseline\t{pct_genes_passing if pct_genes_passing is not None else 'NA'}\n")
 
 
 def main():
     args = parse_args()
+    sample_id = args.sample_id if args.sample_id is not None else sample_id_from_path(args.input)
 
-    if args.sample_id is not None:
-        sample_id = args.sample_id
-    else:
-        sample_id = sample_id_from_path(args.input)
-
-    # Check if outputs already exist
     if not args.force and check_outputs_exist(args):
-        print(f"[SKIP] Sample '{sample_id}' already processed. Output files exist. Use --force to overwrite.")
+        print(f"[SKIP] Sample '{sample_id}' already processed. Use --force to overwrite.")
         sys.exit(0)
 
-    # Validate min-gene-fraction
     if not 0.0 <= args.min_gene_fraction <= 1.0:
-        sys.exit(f"[ERROR] --min-gene-fraction must be between 0.0 and 1.0, got {args.min_gene_fraction}")
+        sys.exit(f"[ERROR] --min-gene-fraction must be 0.0-1.0, got {args.min_gene_fraction}")
+    if not 0.0 <= args.min_query_coverage <= 1.0:
+        sys.exit(f"[ERROR] --min-query-coverage must be 0.0-1.0, got {args.min_query_coverage}")
 
     aln = open_alignment(args.input)
-
-    # Get reference lengths from header
     ref_lengths = get_reference_lengths(aln)
     print(f"[INFO] Found {len(ref_lengths)} references in BAM header")
 
-    per_read, align_counts_with_supp, align_counts_no_supp, gene_coverage = aggregate_per_read_and_alignment_counts(
-        aln,
-        min_mapq=args.min_mapq,
-        include_supplementary=args.include_supplementary,
-        cigar_aware_coverage=args.cigar_aware_coverage,
+    (per_read, align_counts_with_supp, align_counts_no_supp, gene_coverage,
+     gene_query_coverages, total_primary_seen, total_primary_passing) = (
+        aggregate_per_read_and_alignment_counts(
+            aln, min_mapq=args.min_mapq, min_query_coverage=args.min_query_coverage,
+            include_supplementary=args.include_supplementary,
+            cigar_aware_coverage=args.cigar_aware_coverage,
+            coverage_ignore_filters=args.coverage_ignore_filters,
+        )
     )
 
-    # Calculate gene coverage fractions
     gene_fractions = calculate_gene_fractions(gene_coverage, ref_lengths)
-
-    # Determine which genes pass the threshold
+    query_coverage_stats = calculate_query_coverage_stats(gene_query_coverages)
     passing_genes = get_passing_genes(gene_fractions, args.min_gene_fraction)
+    n_genes_baseline = len(gene_coverage)
+
+    pct_retained = round(total_primary_passing / total_primary_seen * 100, 2) if total_primary_seen else 0.0
+    print(f"[INFO] Primary alignments: {total_primary_passing:,} / {total_primary_seen:,} "
+          f"passed --min-mapq {args.min_mapq} + --min-query-coverage {args.min_query_coverage:.0%} "
+          f"({pct_retained:.2f}% retained)")
 
     if passing_genes is not None:
-        num_passing = len(passing_genes)
-        num_total = len(gene_coverage)
-        print(f"[INFO] Gene fraction filter: {num_passing}/{num_total} genes pass >= {args.min_gene_fraction:.1%} coverage")
+        print(f"[INFO] Gene fraction filter: {len(passing_genes)}/{n_genes_baseline} "
+              f"genes pass >= {args.min_gene_fraction:.1%} coverage")
 
-    # Write per-read output (unfiltered - shows all alignments)
     write_read_output(per_read, args.read_output)
 
-    # Write coverage output if requested
     if args.coverage_output:
         write_coverage_output(
-            gene_fractions,
-            ref_lengths,
-            gene_coverage,
-            passing_genes,
-            args.min_gene_fraction,
-            args.coverage_output
+            gene_fractions, ref_lengths, gene_coverage, query_coverage_stats,
+            passing_genes, args.min_gene_fraction, args.coverage_output,
         )
-        print(f"[INFO] Wrote coverage stats to: {args.coverage_output}")
+        print(f"[INFO] Wrote coverage stats (breadth + depth) to: {args.coverage_output}")
 
-    # Apply gene fraction filter to counts based on mode
+    stats_path = args.stats_output or (f"{args.coverage_output}.stats.tsv" if args.coverage_output else None)
+    if stats_path:
+        write_stats_output(
+            stats_path, sample_id, total_primary_seen, total_primary_passing,
+            args.min_mapq, args.min_query_coverage, n_genes_baseline,
+            len(passing_genes) if passing_genes is not None else None,
+            args.min_gene_fraction,
+        )
+        print(f"[INFO] Wrote retained-read stats to: {stats_path}")
+
     if args.count_mode == "read_end":
         gene_counts = summarize_genes_read_end(per_read, passing_genes)
-    else:  # alignment mode
-        if args.include_supplementary:
-            gene_counts = filter_align_counts(align_counts_with_supp, passing_genes)
-        else:
-            gene_counts = filter_align_counts(align_counts_no_supp, passing_genes)
+    else:
+        gene_counts = filter_align_counts(
+            align_counts_with_supp if args.include_supplementary else align_counts_no_supp, passing_genes,
+        )
 
     write_gene_summary(gene_counts, sample_id, args.gene_summary)
 
     print(f"[INFO] Wrote per-read file to: {args.read_output}")
     print(f"[INFO] Wrote per-gene summary to: {args.gene_summary}")
-    print(f"[INFO] Sample ID used: {sample_id}")
-    print(f"[INFO] Count mode: {args.count_mode}")
-    print(f"[INFO] Include supplementary: {args.include_supplementary}")
-    print(f"[INFO] CIGAR-aware coverage: {args.cigar_aware_coverage}")
-    print(f"[INFO] Min gene fraction: {args.min_gene_fraction:.1%}")
+    print(f"[INFO] Sample ID: {sample_id} | Count mode: {args.count_mode} | "
+          f"Min gene fraction: {args.min_gene_fraction:.1%} | "
+          f"Min query coverage: {args.min_query_coverage:.1%}")
 
 
 if __name__ == "__main__":

--- a/bin/combine_seqkit_stats.py
+++ b/bin/combine_seqkit_stats.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""
+combine_seqkit_stats.py
+
+Finds tab-delimited text files (e.g., seqkit stats output) matching a regex
+pattern under a given directory, adds a 'data_group' column derived from each
+file's stem, and writes a single combined TSV.
+
+Usage:
+    python combine_seqkit_stats.py \
+        --path /path/to/results \
+        --pattern ".*counts.*\\.txt$" \
+        --output combined_stats.txt
+
+    # Or search non-recursively:
+    python combine_seqkit_stats.py \
+        --path /path/to/results \
+        --pattern "raw_counts\\.txt$" \
+        --output combined_stats.txt \
+        --no-recursive
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Combine seqkit stats (or similar) TSV files into one, "
+                    "adding a 'data_group' column from each file's stem."
+    )
+    parser.add_argument(
+        "--path", "-p",
+        required=True,
+        help="Root directory to search for matching files."
+    )
+    parser.add_argument(
+        "--pattern", "-r",
+        required=True,
+        help="Regular expression matched against each file's full path. "
+             "Example: '.*raw_counts\\.txt$' or '.*stats.*\\.txt$'"
+    )
+    parser.add_argument(
+        "--output", "-o",
+        required=True,
+        help="Output file path for the combined TSV."
+    )
+    parser.add_argument(
+        "--suffix",
+        default=None,
+        help="Explicit suffix to strip from filenames when building "
+             "data_group (e.g. '.txt'). Defaults to stripping the last "
+             "extension via Path.stem."
+    )
+    parser.add_argument(
+        "--no-recursive",
+        action="store_true",
+        default=False,
+        help="Search only the top-level directory (non-recursive). "
+             "Default is recursive."
+    )
+    parser.add_argument(
+        "--sep",
+        default="\t",
+        help="Field separator used in input files (default: tab)."
+    )
+    return parser.parse_args()
+
+
+def find_files(root: Path, pattern: re.Pattern, recursive: bool) -> list[Path]:
+    """Return all files under root whose full path matches pattern."""
+    glob = root.rglob("*") if recursive else root.glob("*")
+    matched = sorted(
+        f for f in glob
+        if f.is_file() and pattern.search(str(f))
+    )
+    return matched
+
+
+def file_stem(filepath: Path, suffix: str | None) -> str:
+    """Return the data_group label for a file."""
+    if suffix:
+        name = filepath.name
+        return name[: -len(suffix)] if name.endswith(suffix) else name
+    return filepath.stem          # strips only the last extension
+
+
+def read_file(filepath: Path, sep: str) -> pd.DataFrame | None:
+    """Read a TSV/CSV file into a DataFrame, skipping comment lines."""
+    try:
+        df = pd.read_csv(filepath, sep=sep, comment="#")
+        if df.empty:
+            print(f"  [warn] {filepath} is empty — skipping.", file=sys.stderr)
+            return None
+        return df
+    except Exception as exc:
+        print(f"  [warn] Could not read {filepath}: {exc} — skipping.",
+              file=sys.stderr)
+        return None
+
+
+def main():
+    args = parse_args()
+
+    root = Path(args.path)
+    if not root.is_dir():
+        sys.exit(f"ERROR: --path '{args.path}' is not a valid directory.")
+
+    try:
+        pattern = re.compile(args.pattern)
+    except re.error as exc:
+        sys.exit(f"ERROR: Invalid regex '{args.pattern}': {exc}")
+
+    recursive = not args.no_recursive
+    files = find_files(root, pattern, recursive)
+
+    if not files:
+        sys.exit(
+            f"ERROR: No files matched pattern '{args.pattern}' "
+            f"under '{root}' ({'recursive' if recursive else 'non-recursive'})."
+        )
+
+    print(f"Found {len(files)} matching file(s):")
+    frames = []
+    for f in files:
+        group = file_stem(f, args.suffix)
+        print(f"  {f}  →  data_group='{group}'")
+        df = read_file(f, args.sep)
+        if df is None:
+            continue
+        df.insert(0, "data_group", group)   # prepend so it's the first column
+        frames.append(df)
+
+    if not frames:
+        sys.exit("ERROR: No files could be read successfully.")
+
+    combined = pd.concat(frames, ignore_index=True)
+
+    out = Path(args.output)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    combined.to_csv(out, sep="\t", index=False)
+
+    print(f"\nCombined {len(frames)} file(s) → {out}")
+    print(f"Total rows : {len(combined):,}")
+    print(f"Columns    : {list(combined.columns)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/combine_sweep_results.py
+++ b/bin/combine_sweep_results.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""
+combine_sweep_results.py
+════════════════════════════════════════════════════════════════════════════════
+
+Combines per-sample outputs from coverage_threshold_sweep.py (run one sample at
+a time) into single matrices — one per output file type — with a sample_id
+column injected from each file's name, so every sample and file type becomes one
+queryable table, ready for plot_sweep_dropoff.R.
+
+Scans a single directory for files matching the known suffixes:
+    <prefix>_results.csv, <prefix>_gene_detail.csv,
+    <prefix>_redundancy.csv, <prefix>_length_quantiles.csv
+where <prefix> is the BAM filename minus ".bam". From that:
+    sample_id  = the full prefix (BAM basename), preserved as-is.
+
+OUTPUT
+──────
+combined_results.csv, combined_gene_detail.csv, combined_redundancy.csv,
+combined_length_quantiles.csv (only the types that actually exist in the input
+are produced) — each with a sample_id column prepended. Written progressively;
+each output file is cleared once at the start of this run.
+
+Usage:
+    python combine_sweep_results.py sweep_results/ --out-dir combined/
+"""
+
+import argparse
+import csv
+import sys
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+FILE_TYPES = {
+    "_results.csv":          "results",
+    "_gene_detail.csv":      "gene_detail",
+    "_redundancy.csv":       "redundancy",
+    "_length_quantiles.csv": "length_quantiles",
+}
+
+
+def classify_filename(fname: str) -> Optional[Tuple[str, str]]:
+    """Returns (prefix, file_type) if fname matches a known suffix, else None."""
+    for suffix, ftype in FILE_TYPES.items():
+        if fname.endswith(suffix):
+            return fname[: -len(suffix)], ftype
+    return None
+
+
+def make_combiner(out_dir: Path):
+    """
+    Per-file-type streaming appender: header written on the first row for that
+    file type, appended after. Clears any pre-existing combined_*.csv from a
+    previous run the first time each file type is touched, so reruns don't
+    silently double up data.
+    """
+    written = set()
+
+    def append_rows(rows: List[dict], file_type: str):
+        if not rows:
+            return
+        p = out_dir / f"combined_{file_type}.csv"
+        first = file_type not in written
+        if first and p.exists():
+            p.unlink()
+        with open(p, "a", newline="") as fh:
+            writer = csv.DictWriter(fh, fieldnames=list(rows[0].keys()))
+            if first:
+                writer.writeheader()
+            writer.writerows(rows)
+        if first:
+            written.add(file_type)
+            print(f"  created combined_{file_type}.csv", flush=True)
+
+    return append_rows
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("input_dir", help="Directory holding the per-sample sweep CSVs")
+    ap.add_argument("--out-dir", default="combined_sweep_results")
+    args = ap.parse_args()
+
+    root = Path(args.input_dir)
+    if not root.is_dir():
+        sys.exit(f"[ERROR] {root} is not a directory")
+
+    sweep_files = sorted(
+        f for f in root.iterdir() if f.is_file() and classify_filename(f.name)
+    )
+    if not sweep_files:
+        sys.exit(f"[ERROR] No matching *_results.csv / *_gene_detail.csv / etc. files "
+                 f"found in {root}")
+
+    print(f"[INFO] Found {len(sweep_files)} sweep file(s) in {root}", flush=True)
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    append_rows = make_combiner(out_dir)
+
+    counts = {ft: 0 for ft in set(FILE_TYPES.values())}
+    n_files = 0
+
+    for f in sweep_files:
+        prefix, file_type = classify_filename(f.name)
+        sample_id = prefix  # full BAM basename; no token-splitting
+
+        with open(f, newline="") as fh:
+            reader = csv.DictReader(fh)
+            if not reader.fieldnames:
+                continue
+            first_col = reader.fieldnames[0]
+            rows = []
+            for row in reader:
+                # Defensive: skip an embedded header row, in case this file was
+                # ever manually concatenated before reaching us.
+                if row.get(first_col) == first_col:
+                    continue
+                rows.append({"sample_id": sample_id, **row})
+
+        append_rows(rows, file_type)
+        counts[file_type] += len(rows)
+        n_files += 1
+
+    print(f"\n[INFO] Combined {n_files} file(s):", flush=True)
+    for ft, n in counts.items():
+        if n:
+            print(f"    {ft:<18} {n:,} rows -> combined_{ft}.csv", flush=True)
+    print(f"\nOutput: {out_dir}/", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/coverage_threshold_sweep.py
+++ b/bin/coverage_threshold_sweep.py
@@ -1,0 +1,998 @@
+#!/usr/bin/env python3
+"""
+coverage_threshold_sweep.py
+════════════════════════════════════════════════════════════════════════════════
+
+Single-pass-then-sweep diagnostic for choosing --min-query-coverage and
+--min-gene-fraction thresholds for alignment_analyzer.py.
+
+WHY A SEPARATE SCRIPT
+──────────────────────
+alignment_analyzer.py applies one fixed pair of thresholds per run. Testing
+N query-coverage values x M gene-fraction values by re-running it N*M times
+would re-scan a multi-gigabyte BAM N*M times. This script reads every
+PRIMARY mapped alignment's (gene, mapq, query_coverage_pct, reference span,
+read_length, alignment_length) ONCE into a small intermediate CSV, then
+evaluates the entire threshold grid as fast DuckDB queries + in-memory
+interval merges — no further BAM reads.
+
+WHAT'S IN THIS VERSION
+─────────────────────────
+1. Two "retained" columns, on purpose (see below) — n_alignments_retained
+   (qcov filter alone) vs n_alignments_in_passing_genes (qcov + gene_fraction
+   together).
+2. --exclude-snp-confirmation: drops alignments to genes flagged
+   "RequiresSNPConfirmation" in MEGARes. Coverage of these genes only tells
+   you the (often universally-conserved) gene is present — NOT that the
+   specific resistance-conferring point mutation was observed. Applied as a
+   fixed pre-filter alongside --min-mapq, before any threshold sweep.
+3. Class/Mechanism/Group pass-counts added directly to the main grid output,
+   so you can see how taxonomy-level detection is affected without needing
+   the separate batch/taxonomy pipeline.
+4. --redundancy-output: quantifies multi-mapping redundancy — groups of
+   near-identical reference accessions (same Group label, similar length,
+   each propped up by only a couple of reads) that are very likely the same
+   underlying signal split across redundant database entries by alignment
+   tie-breaking, rather than independent evidence.
+5. --gene-detail-output gains taxonomy columns and per-gene read_length /
+   alignment_length quantiles (p10/median/p90).
+6. --length-quantiles-output: dataset-wide read_length / alignment_length
+   quantiles (p5/p10/p25/median/p75/p90/p95) per query-coverage threshold —
+   a quick characterization of your read-length distribution independent of
+   any one gene.
+
+READING THE OUTPUT — TWO DIFFERENT "RETAINED" COLUMNS, ON PURPOSE
+────────────────────────────────────────────────────────────────────
+  n_alignments_retained / pct_alignments_retained_of_baseline
+      Alignments passing --min-query-coverage ALONE. Identical across every
+      min_gene_fraction row for a given min_query_coverage.
+  n_alignments_in_passing_genes / pct_alignments_in_passing_genes_of_baseline
+      Alignments belonging to a gene that ALSO clears min_gene_fraction.
+  n_genes_at_qcov_threshold / n_genes_passing_both / pct_genes_passing_of_baseline_genes
+      Gene COUNTS, not alignment counts.
+  n_classes_passing / n_mechanisms_passing / n_groups_passing
+      Distinct taxonomy categories with >=1 gene passing both filters.
+
+It's normal for alignment-retention to stay high while gene/category counts
+drop sharply — alignment counts per gene are typically very skewed.
+
+BREADTH APPROXIMATION
+───────────────────────
+Gene-length breadth is the UNION OF [reference_start, reference_end)
+INTERVALS of qualifying alignments — not full CIGAR-aware position tracking
+like alignment_analyzer.py's --cigar-aware-coverage. Close approximation for
+typical short-read alignments; use this to narrow down thresholds, then
+confirm the exact number for your final pair with --cigar-aware-coverage.
+
+7. Fragment-aware hit counting (n_fragment_hits): a paired fragment where
+   both mates agree on the same gene counts as ONE hit, not two. If only one
+   mate is classified, that's still one hit. If the mates disagree, each
+   gene gets its own hit (two total) — disagreement is itself informative,
+   so it's not collapsed away. This applies uniformly to PE fragments and to
+   the not-combined ("unmerged") subset of a merge workflow, since both
+   share the same base_read_id structure; a true FLASH-merged read has no
+   mate at all and trivially counts as one hit through the same code path.
+   This sits alongside the existing alignment-record-based counts (read_count,
+   n_alignments_retained, etc.) rather than replacing them, since those
+   remain meaningful on their own — n_fragment_hits is what you want when
+   comparing PE and merged workflows on equal footing, since raw alignment
+   counts otherwise double-count concordant PE pairs relative to a single
+   merged read covering the same physical fragment.
+
+Usage:
+    python coverage_threshold_sweep.py -i sample.bam -o sweep_results.csv \\
+        --min-mapq 0 \\
+        --exclude-snp-confirmation \\
+        --query-coverage-sweep 0,0.5,0.6,0.7,0.8,0.9,0.95 \\
+        --gene-fraction-sweep 0,0.1,0.25,0.5,0.8 \\
+        --gene-detail-output gene_detail.csv \\
+        --redundancy-output redundancy.csv \\
+        --length-quantiles-output length_quantiles.csv
+"""
+
+import argparse
+import csv
+import os
+import re
+import statistics
+import sys
+import tempfile
+from collections import defaultdict
+from typing import Dict, List, Tuple, Optional
+
+import duckdb
+import pysam
+
+# Same stripping convention used throughout this pipeline: a FLASH-merged
+# read's name ends in '.extendedFrags...' with no mate suffix; a not-combined
+# PE mate ends in '/1', '/2', '.1', or '.2'. Stripping both yields one
+# base_read_id per physical fragment regardless of which case applies.
+_RE_FLASH = re.compile(r'\.(extendedFrags|notCombined)[^/]*$')
+_RE_PAIR  = re.compile(r'[/\.][12]$')
+
+
+def get_base_read_id(read_id: str) -> str:
+    base = _RE_FLASH.sub('', read_id)
+    return _RE_PAIR.sub('', base)
+
+
+def edge_aware_query_length(read, ref_length: int) -> int:
+    """
+    Coverage-anchored read length for query-coverage (qcov). Identical logic to
+    alignment_analyzer.edge_aware_query_length so the two tools agree.
+
+    Fixes two things vs raw read.query_length:
+      1. Soft- vs hard-clip asymmetry (query_length includes soft clips but not
+         hard clips). Full physical length is rebuilt from the CIGAR (aligned +
+         both clip types, ops 4=S, 5=H) so the aligner's clip choice is irrelevant.
+      2. Reference-edge overhang: clip bases that fall outside [0, ref_length)
+         couldn't have aligned (the gene simply ended) and are discounted from the
+         denominator, so a read running off a short gene's edge isn't penalized.
+
+    Returns read bases that HAD A CHANCE to align; never below query_alignment_length.
+    """
+    if read.cigartuples is None:
+        return read.query_alignment_length or 0
+    aln_len = read.query_alignment_length or 0
+    ops = read.cigartuples
+    lead_clip = ops[0][1] if ops and ops[0][0] in (4, 5) else 0
+    trail_clip = ops[-1][1] if len(ops) > 1 and ops[-1][0] in (4, 5) else 0
+    total_physical = aln_len + lead_clip + trail_clip
+    ref_start = read.reference_start if read.reference_start is not None else 0
+    ref_end = read.reference_end if read.reference_end is not None else 0
+    overhang_5 = max(0, lead_clip - ref_start)
+    overhang_3 = max(0, trail_clip - (ref_length - ref_end)) if ref_length else 0
+    eff = total_physical - overhang_5 - overhang_3
+    return max(eff, aln_len)
+
+
+def parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("-i", "--input", required=True, nargs="+",
+                    help=(
+                        "Input BAM/SAM. Accepts one or more paths (e.g. "
+                        "-i merged.bam unmerged.bam) to treat several files as ONE logical "
+                        "sample — every alignment from every file given is combined into "
+                        "the same per-gene breadth/fragment-hit computation. Use this for a "
+                        "merge-workflow sample split across a merged BAM and a not-combined "
+                        "(unmerged) BAM: gene_fraction needs the union of intervals from "
+                        "BOTH to be correct, since breadth from two non-overlapping subsets "
+                        "doesn't average — it has to be computed from the combined raw "
+                        "alignments, not reconstructed from two separate breadth numbers "
+                        "after the fact. Safer than pointing this at an externally-merged "
+                        "Combined/ BAM, since this pipeline has previously found Combined/ "
+                        "BAMs to triple-count reads depending on what went into the merge — "
+                        "passing the original source files here sidesteps that risk entirely."
+                    ))
+    ap.add_argument("-o", "--output", required=True, help="Output sweep-grid CSV")
+    ap.add_argument("--min-mapq", type=int, default=0,
+                    help="Fixed MAPQ floor applied to every grid cell (default 0)")
+    ap.add_argument("--edge-aware-qcov", dest="edge_aware_qcov", action="store_true", default=True,
+                    help="(DEFAULT ON) Compute qcov (and match_qcov) against a coverage-anchored "
+                         "read length: rebuild full length from the CIGAR so soft/hard "
+                         "clips are equivalent, and discount clip bases that overhang "
+                         "the reference edge (a read running off a short gene's end is "
+                         "not penalized). Only affects read-axis qcov metrics; gene "
+                         "breadth is unaffected. Matches alignment_analyzer.py's flag. "
+                         "Use --no-edge-aware-qcov to disable.")
+    ap.add_argument("--no-edge-aware-qcov", dest="edge_aware_qcov", action="store_false",
+                    help="Disable edge-aware qcov (use raw read.query_length as denominator).")
+    ap.add_argument("--min-aln-length", type=int, default=0,
+                    help=(
+                        "Fixed ABSOLUTE aligned-length floor (in bp), applied alongside "
+                        "every swept --query-coverage-sweep value rather than replacing it. "
+                        "Catches reads that don't have ENOUGH absolute matching sequence "
+                        "even if their percentage technically passes (most relevant for "
+                        "short reads). Default 0 (disabled)."
+                    ))
+    ap.add_argument("--max-unaligned-length", type=int, default=None,
+                    help=(
+                        "Fixed ABSOLUTE cap (in bp) on read_length - aln_length, applied "
+                        "alongside every swept --query-coverage-sweep value. Catches the "
+                        "OTHER direction: a long read (e.g. a 300bp FLASH-merged read) can "
+                        "clear a 50%% query-coverage bar while still leaving 150bp "
+                        "unexplained, far more absolute unaligned sequence than the same "
+                        "50%% would tolerate on a 150bp read. Combined with the qcov_pct "
+                        "sweep, this naturally makes longer reads satisfy a STRICTER "
+                        "effective percentage without needing a different --query-coverage- "
+                        "sweep value per read-length stratum: at a fixed cap, a 300bp read's "
+                        "effective bar tightens automatically relative to a 150bp read's, "
+                        "exactly compensating for read length rather than ignoring it. "
+                        "Default None (disabled, identical to previous behavior)."
+                    ))
+    ap.add_argument("--exclude-snp-confirmation", action="store_true", default=False,
+                    help=(
+                        "Exclude alignments to genes flagged 'RequiresSNPConfirmation' "
+                        "in MEGARes (e.g. RPOB, GYRA, 16S/23S rRNA mutation markers). "
+                        "These are often universally-conserved housekeeping genes where "
+                        "coverage alone does NOT confirm the specific resistance "
+                        "mutation was observed. Applied as a fixed pre-filter, like "
+                        "--min-mapq, before the threshold sweep."
+                    ))
+    ap.add_argument("--group-aware", "--group-aware-discordant", dest="group_aware",
+                    action="store_true", default=True,
+                    help=(
+                        "(DEFAULT ON) Changes how a fragment whose two mates classify to "
+                        "DIFFERENT gene_accessions is counted (see resolve_fragment_hits() "
+                        "docstring for full reasoning). With this ON, mates that disagree on "
+                        "gene_accession but share the same MEGARes Group are treated as the "
+                        "SAME underlying signal split across redundant database entries (the "
+                        "multi-mapping artifact tracked via --redundancy-output) and "
+                        "counted as ONE hit, credited to whichever mate has the higher "
+                        "match_qcov_pct. Genuine cross-Group disagreement (mates hit "
+                        "truly different Groups) is instead counted as ONE hit to EACH "
+                        "gene, since both mechanisms are real evidence; tracked "
+                        "separately in the console diagnostics so you can see "
+                        "how often each case actually occurs. Group is parsed from the "
+                        "MEGARes pipe-delimited reference name. Use --no-group-aware "
+                        "to restore legacy behavior (both genes get 1 hit each, 2 total). "
+                        "(--group-aware-discordant is a backward-compatible alias.)"
+                    ))
+    ap.add_argument("--no-group-aware", "--no-group-aware-discordant", dest="group_aware",
+                    action="store_false",
+                    help="Disable group-aware resolution; mates that disagree on "
+                         "gene_accession each get their own hit (legacy behavior).")
+    ap.add_argument("--query-coverage-sweep", default="0,0.5,0.6,0.7,0.8,0.9,0.95",
+                    help="Comma-separated min-query-coverage values to test (0-1). "
+                         "Set to '0' to disable qcov filtering and use identity-sweep alone.")
+    ap.add_argument("--gene-fraction-sweep", default="0,0.1,0.25,0.5,0.8",
+                    help="Comma-separated min-gene-fraction values to test (0-1)")
+    ap.add_argument("--identity-sweep", default="0",
+                    help=(
+                        "Comma-separated minimum percent-identity values to sweep (0-100). "
+                        "Identity = (query_alignment_length - NM) / query_alignment_length * 100, "
+                        "measuring how similar the ALIGNED PORTION of each read is to the "
+                        "reference, independent of how much of the read aligned (qcov handles "
+                        "that). Default '0' (no identity filtering, same as previous behavior). "
+                        "Typical sweep: '0,80,90,95,97'. "
+                        "Reads missing an NM tag pass at identity=0 but are excluded at any "
+                        "higher threshold. Can be used alongside --query-coverage-sweep to "
+                        "produce a 3-axis grid, or set --query-coverage-sweep 0 to sweep "
+                        "identity × gene-fraction only."
+                    ))
+    ap.add_argument("--match-qcov-sweep", default="0",
+                    help=(
+                        "Comma-separated minimum 'match-only query-coverage' values to sweep "
+                        "(0-100). match_qcov_pct = (query_alignment_length - NM) / "
+                        "query_length * 100 — what fraction of the WHOLE read is explained "
+                        "by genuine matches, with both clipped bases AND mismatches/indels "
+                        "excluded from the numerator. Unlike plain --query-coverage-sweep "
+                        "(which only checks clipping, blind to mismatches) this also "
+                        "penalizes a fully-aligned-but-noisy read. Unlike --identity-sweep "
+                        "alone (which only checks the aligned portion's quality, blind to "
+                        "extent) this also penalizes a short-but-clean fragment — and "
+                        "because NM >= 0, match_qcov_pct can NEVER exceed plain qcov_pct, so "
+                        "a short fragment is capped at its own length-driven ceiling no "
+                        "matter how clean it is; high identity cannot 'rescue' a short hit "
+                        "the way it might first seem to. Default '0' (disabled, same as "
+                        "previous behavior). Typical sweep for filtering on this alone: "
+                        "'0,50,60,70,80,90'. Designed to be used INSTEAD of separately "
+                        "sweeping --query-coverage-sweep and --identity-sweep, when you want "
+                        "extent and quality combined into a single filtering decision rather "
+                        "than tracked as two independent diagnostic axes — set "
+                        "--query-coverage-sweep 0 --identity-sweep 0 and sweep this instead."
+                    ))
+    ap.add_argument("--tmp-csv", default=None,
+                    help="Where to write the intermediate per-alignment CSV "
+                         "(default: temp file, deleted after run)")
+    ap.add_argument("--keep-tmp-csv", action="store_true", default=False,
+                    help="Don't delete the intermediate per-alignment CSV after the run")
+    ap.add_argument("--gene-detail-output", default=None,
+                    help="Optional CSV: per-gene breadth, read count, taxonomy, and "
+                         "read/alignment-length quantiles at each swept qcov threshold.")
+    ap.add_argument("--redundancy-output", default=None,
+                    help="Optional CSV: per-Group multi-mapping redundancy metrics at "
+                         "each swept qcov threshold (see module docstring point 4).")
+    ap.add_argument("--length-quantiles-output", default=None,
+                    help="Optional CSV: dataset-wide read_length/alignment_length "
+                         "quantiles at each swept qcov threshold.")
+    return ap.parse_args()
+
+
+def parse_gene_reference(ref_name: str) -> Tuple[str, str, str, str, str, str]:
+    """MEGARes pipe-delimited name -> (MEG_ID, Type, Class, Mechanism, Group, SNP)."""
+    parts = ref_name.split('|')
+    if len(parts) >= 5:
+        return (parts[0], parts[1], parts[2], parts[3], parts[4],
+                parts[5] if len(parts) > 5 else '')
+    return (ref_name, '', '', '', '', '')
+
+
+def percentile(sorted_vals: List[float], q: float) -> float:
+    """Linear-interpolation percentile (q in 0-100), robust down to n=1."""
+    if not sorted_vals:
+        return 0.0
+    if len(sorted_vals) == 1:
+        return float(sorted_vals[0])
+    k = (len(sorted_vals) - 1) * (q / 100.0)
+    f = int(k)
+    c = min(f + 1, len(sorted_vals) - 1)
+    if f == c:
+        return float(sorted_vals[f])
+    return sorted_vals[f] * (c - k) + sorted_vals[c] * (k - f)
+
+
+def stream_primary_alignments_to_csv(
+    bam_paths: List[str], out_csv: str, min_mapq: int,
+    exclude_snp_confirmation: bool, edge_aware_qcov: bool = False
+) -> Tuple[int, Dict[str, int], int]:
+    """
+    Single pass over EACH BAM in bam_paths (e.g. a sample's merged BAM and
+    its not-combined/unmerged BAM together), writing every PRIMARY MAPPED
+    alignment passing --min-mapq AND (if requested) not flagged
+    RequiresSNPConfirmation into ONE shared per-alignment CSV. Both filters
+    are fixed for the whole sweep, applied here once.
+
+    Combining multiple files here (rather than relying on a pre-merged BAM)
+    means gene_fraction/breadth downstream is computed from the TRUE union
+    of intervals across every file — base_read_id collisions across files
+    aren't a concern for files belonging to the same sample, since a given
+    original fragment is FLASH-assigned to exactly one of merged/unmerged,
+    never both, so read IDs don't collide between the two.
+
+    Returns (total_primary_seen_before_any_filter, ref_lengths, n_excluded_by_snp).
+    """
+    total_seen = 0
+    n_excluded_by_snp = 0
+    out_dir = os.path.dirname(out_csv)
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
+
+    ref_lengths: Dict[str, int] = {}
+
+    with open(out_csv, "w", newline="") as fh:
+        writer = csv.writer(fh)
+        # 'blocks' replaces the old ref_start/ref_end pair. get_blocks()
+        # returns the CIGAR-aware list of gapless aligned segments, correctly
+        # splitting around deletions (D/N) — a read with CIGAR 40M10D50M
+        # produces "start:50;60:end" rather than one span "start:end" that
+        # silently counts the 10bp deletion gap as covered. This matches
+        # ResistomeAnalyzer's per-base CIGAR walk for deletions, and fixes
+        # the one blind spot the old interval-span approach had.
+        writer.writerow(["gene_accession", "mapq", "qcov_pct",
+                         "read_length", "aln_length", "base_read_id",
+                         "pct_identity", "match_qcov_pct", "matched_length", "blocks"])
+
+        for bam_path in bam_paths:
+            with pysam.AlignmentFile(bam_path, "rb", check_sq=False) as bam:
+                ref_lengths.update(dict(zip(bam.references, bam.lengths)))
+
+                for read in bam.fetch(until_eof=True):
+                    if read.flag & 0x900:
+                        continue
+                    if read.is_unmapped:
+                        continue
+                    total_seen += 1
+
+                    if read.mapping_quality < min_mapq:
+                        continue
+
+                    gene = bam.get_reference_name(read.reference_id)
+
+                    if exclude_snp_confirmation:
+                        snp_field = gene.split('|')[-1] if '|' in gene else ''
+                        if snp_field == 'RequiresSNPConfirmation':
+                            n_excluded_by_snp += 1
+                            continue
+
+                    qlen = read.query_length or 0
+                    aln_len = read.query_alignment_length or 0
+                    if edge_aware_qcov:
+                        _ref_len = ref_lengths.get(gene, 0)
+                        qlen = edge_aware_query_length(read, _ref_len)
+                    qcov_pct = round(aln_len / qlen * 100.0, 2) if qlen else 0.0
+                    base_id = get_base_read_id(read.query_name)
+
+                    # NM tag (edit distance) = mismatches + inserted bases +
+                    # deleted reference bases. Absent in some poorly-formed SAMs;
+                    # we write NULL rather than silently assigning 0% or 100%.
+                    # pct_identity = (aln_len - NM) / aln_len * 100
+                    #   -> 100% = every aligned base matches perfectly
+                    #   -> lower values = sum of all edit events as a fraction
+                    #      of the aligned (non-clipped) query length.
+                    # Soft clips are correctly excluded from both aln_len and NM
+                    # so clipping alone doesn't penalize identity — only real
+                    # mismatches/indels inside the aligned region do.
+                    try:
+                        nm = read.get_tag('NM')
+                        pct_identity = round((aln_len - nm) / aln_len * 100.0, 2) if aln_len else 0.0
+                        # match_qcov_pct = what fraction of the WHOLE read is
+                        # explained by genuine matches (clipped bases AND
+                        # mismatches/indels both excluded from the numerator).
+                        # Mathematically: match_qcov_pct = qcov_pct * pct_identity / 100,
+                        # and since NM >= 0, match_qcov_pct can never exceed
+                        # qcov_pct — a short fragment is capped at its own
+                        # qcov_pct ceiling regardless of how clean it is, so
+                        # this metric can't be "rescued" by high identity the
+                        # way a naive intuition might worry about. It directly
+                        # answers "how much of this read is confidently,
+                        # correctly explained by this reference," combining
+                        # extent and quality into one number.
+                        match_qcov_pct = round((aln_len - nm) / qlen * 100.0, 2) if qlen else 0.0
+                        # matched_length = absolute bp of TRUE matches, i.e.
+                        # aln_length with mismatches/indels (NM) subtracted
+                        # out. The exact integer underlying both pct_identity
+                        # (matched_length / aln_length) and match_qcov_pct
+                        # (matched_length / read_length) — stored directly so
+                        # downstream length distributions don't have to
+                        # re-derive it from already-rounded percentages.
+                        matched_length = aln_len - nm
+                    except KeyError:
+                        pct_identity = None
+                        match_qcov_pct = None
+                        matched_length = None
+
+                    raw_blocks = read.get_blocks()
+                    blocks_str = (
+                        ";".join(f"{s}:{e}" for s, e in raw_blocks)
+                        if raw_blocks
+                        else f"{read.reference_start}:{read.reference_end}"
+                    )
+
+                    writer.writerow([gene, read.mapping_quality, qcov_pct,
+                                     qlen, aln_len, base_id,
+                                     pct_identity, match_qcov_pct, matched_length, blocks_str])
+
+    return total_seen, ref_lengths, n_excluded_by_snp
+
+
+def resolve_fragment_hits(
+    rows: List[Tuple[str, str, float]],
+    taxonomy_cache: Optional[Dict[str, Tuple[str, str, str, str, str, str]]] = None,
+    group_aware: bool = False,
+) -> Tuple[Dict[str, int], Dict[str, int]]:
+    """
+    rows: list of (gene_accession, base_read_id, match_qcov_pct) for
+    alignments passing the current threshold combination. match_qcov_pct is
+    only used as a tie-breaker when group_aware=True; pass 0.0 if unused.
+
+    DEFAULT (group_aware=False — exact previous behavior, unchanged):
+      both mates agree on gene_accession -> 1 hit
+      only one mate present              -> 1 hit
+      mates disagree on gene_accession   -> 1 hit to EACH gene (2 total)
+
+    group_aware=True (opt-in): before treating a gene-level disagreement as
+    real discordance, check whether the two accessions share the same
+    MEGARes Group. If they do, this is almost certainly the multi-mapping/
+    redundant-accession artifact this pipeline has tracked all along via
+    the redundancy diagnostics (BWA's tie-breaking among near-identical
+    database entries) — both mates agree on what's biologically there, they
+    just landed on different specific accessions. Counted as ONE hit,
+    credited to whichever mate has the higher match_qcov_pct (the
+    established combined extent+quality confidence metric).
+
+    Genuine cross-Group disagreement (the two accessions belong to
+    DIFFERENT Groups entirely — e.g. one mate hits a beta-lactamase, the
+    other an aminoglycoside-modifying enzyme) is a real, more concerning
+    signal: a chimeric fragment, PCR artifact, contamination, or a bad
+    FLASH merge. Also resolved to ONE hit (the higher-match_qcov_pct mate),
+    rather than doubling the count for what's likely noise either way —
+    but tracked separately in diagnostics so you can see how often this
+    actually happens, since it's a meaningfully different situation from
+    same-Group disagreement.
+
+    A true single/merged read has no mate sharing its base_read_id, so it
+    falls into the "only one present" case trivially — same code path, no
+    special-casing needed for merged vs PE.
+
+    Returns (hits, diagnostics):
+      hits        — gene_accession -> fragment-hit count
+      diagnostics — counts of each resolution case actually encountered:
+                    'same_gene', 'one_mate_only',
+                    'same_group_diff_gene' (group_aware only),
+                    'cross_group_both_counted' (group_aware only),
+                    'legacy_discordant_both_counted' (group_aware=False only)
+    """
+    frag_groups: Dict[str, List[Tuple[str, float]]] = defaultdict(list)
+    for gene, base_id, mq in rows:
+        frag_groups[base_id].append((gene, mq))
+
+    hits: Dict[str, int] = defaultdict(int)
+    diagnostics: Dict[str, int] = defaultdict(int)
+
+    for base_id, entries in frag_groups.items():
+        if len(entries) == 1:
+            hits[entries[0][0]] += 1
+            diagnostics['one_mate_only'] += 1
+        elif len(entries) == 2:
+            (g1, mq1), (g2, mq2) = entries
+            if g1 == g2:
+                hits[g1] += 1
+                diagnostics['same_gene'] += 1
+            elif group_aware:
+                group1 = (taxonomy_cache or {}).get(g1, (g1, '', '', '', '', ''))[4]
+                group2 = (taxonomy_cache or {}).get(g2, (g2, '', '', '', '', ''))[4]
+                if group1 and group1 == group2:
+                    # Same Group, different accession = redundant-DB-entry artifact.
+                    # Collapse to ONE hit for the higher-match_qcov mate (mq1/mq2).
+                    winner = g1 if mq1 >= mq2 else g2
+                    hits[winner] += 1
+                    diagnostics['same_group_diff_gene'] += 1
+                else:
+                    # Genuinely different Groups = a real cross-mechanism fragment.
+                    # Count ONE hit to EACH gene (both mechanisms evidenced).
+                    hits[g1] += 1
+                    hits[g2] += 1
+                    diagnostics['cross_group_both_counted'] += 1
+            else:
+                hits[g1] += 1          # mates disagree -> one hit each (legacy)
+                hits[g2] += 1
+                diagnostics['legacy_discordant_both_counted'] += 1
+        else:
+            # Shouldn't happen — each base_read_id should have at most one
+            # primary alignment per mate (R1, R2, or single). If it does,
+            # fall back to counting each entry separately rather than guessing.
+            for g, _ in entries:
+                hits[g] += 1
+            diagnostics['unexpected_3plus'] += 1
+    return hits, diagnostics
+
+
+def merged_interval_length(intervals: List[Tuple[int, int]]) -> int:
+    if not intervals:
+        return 0
+    intervals = sorted(intervals)
+    total = 0
+    cur_start, cur_end = intervals[0]
+    for s, e in intervals[1:]:
+        if s <= cur_end:
+            cur_end = max(cur_end, e)
+        else:
+            total += cur_end - cur_start
+            cur_start, cur_end = s, e
+    total += cur_end - cur_start
+    return total
+
+
+def compute_redundancy_table(
+    threshold_labels: Dict[str, float],
+    gene_data: Dict[str, dict],
+    gene_fragment_hits: Dict[str, int],
+    ref_lengths: Dict[str, int],
+    taxonomy_cache: Dict[str, Tuple[str, str, str, str, str, str]],
+) -> List[dict]:
+    """
+    Groups gene accessions by their taxonomy Group field and quantifies
+    multi-mapping redundancy: many accessions, each backed by only a few
+    reads, all roughly the same length, with no single accession dominating
+    the read count -> strong sign these are the SAME underlying signal split
+    across near-duplicate reference entries by alignment tie-breaking,
+    rather than independent distinct hits.
+
+    threshold_labels: dict of column_name -> value, prepended to every output
+    row (e.g. {"min_query_coverage": 0.0, "min_identity": 90.0,
+    "min_match_qcov": 0.0}) — generalized from a single qcov argument so the
+    redundancy table stays labeled correctly across however many threshold
+    axes are actually being swept.
+
+    Reports both the raw alignment-record count (total_reads, as before) and
+    the fragment-hit count (total_fragment_hits). A concordant PE pair
+    inflates total_reads to 2 for what is really one piece of evidence —
+    total_fragment_hits is the fairer number when comparing a PE workflow's
+    redundancy against a merged workflow's.
+    """
+    by_group: Dict[str, List[Tuple[str, int, int, int]]] = defaultdict(list)
+    for gene, d in gene_data.items():
+        n = len(d['read_lengths'])
+        if n == 0:
+            continue
+        _, _, _, _, group, _ = taxonomy_cache.get(gene, (gene, '', '', '', '', ''))
+        if not group:
+            continue
+        by_group[group].append((gene, n, ref_lengths.get(gene, 0), gene_fragment_hits.get(gene, 0)))
+
+    rows = []
+    for group, entries in by_group.items():
+        n_accessions = len(entries)
+        total_reads = sum(e[1] for e in entries)
+        max_reads = max(e[1] for e in entries)
+        total_hits = sum(e[3] for e in entries)
+        max_hits = max(e[3] for e in entries) if entries else 0
+        lengths = [e[2] for e in entries if e[2] > 0]
+        mean_length = statistics.mean(lengths) if lengths else 0.0
+        length_cv = (
+            statistics.pstdev(lengths) / mean_length
+            if (len(lengths) > 1 and mean_length > 0) else 0.0
+        )
+        pct_top = round(max_reads / total_reads * 100, 2) if total_reads else 0.0
+        pct_top_hits = round(max_hits / total_hits * 100, 2) if total_hits else 0.0
+
+        # Heuristic flag — adjust thresholds to taste; raw columns are kept
+        # so you can re-sort/re-filter with your own criteria instead.
+        likely_redundant = (n_accessions >= 5 and pct_top < 50 and length_cv < 0.10)
+
+        rows.append({
+            **threshold_labels,
+            "group": group,
+            "n_accessions": n_accessions,
+            "total_reads": total_reads,
+            "max_accession_reads": max_reads,
+            "pct_reads_in_top_accession": pct_top,
+            "total_fragment_hits": total_hits,
+            "max_accession_fragment_hits": max_hits,
+            "pct_fragment_hits_in_top_accession": pct_top_hits,
+            "mean_gene_length": round(mean_length, 1),
+            "gene_length_cv": round(length_cv, 4),
+            "likely_redundant": likely_redundant,
+        })
+    return rows
+
+
+def main():
+    args = parse_args()
+
+    qcov_values       = sorted(float(x) for x in args.query_coverage_sweep.split(","))
+    gf_values         = sorted(float(x) for x in args.gene_fraction_sweep.split(","))
+    identity_values   = sorted(float(x) for x in args.identity_sweep.split(","))
+    match_qcov_values = sorted(float(x) for x in args.match_qcov_sweep.split(","))
+
+    for values, name, lo, hi in [
+        (qcov_values,       "query-coverage", 0.0, 1.0),
+        (gf_values,         "gene-fraction",  0.0, 1.0),
+        (identity_values,   "identity",       0.0, 100.0),
+        (match_qcov_values, "match-qcov",     0.0, 100.0),
+    ]:
+        for x in values:
+            if not lo <= x <= hi:
+                sys.exit(f"[ERROR] {name} sweep values must be {lo}-{hi}, got {x}")
+
+    tmp_csv = args.tmp_csv or tempfile.mktemp(suffix=".csv")
+    if len(args.input) > 1:
+        print(f"[INFO] Scanning {len(args.input)} input files as ONE sample -> {tmp_csv}", flush=True)
+        for p in args.input:
+            print(f"         {p}", flush=True)
+    else:
+        print(f"[INFO] Scanning {args.input[0]} once -> {tmp_csv}", flush=True)
+    if args.exclude_snp_confirmation:
+        print("[INFO] --exclude-snp-confirmation is ON: genes flagged "
+              "RequiresSNPConfirmation will be dropped entirely from this analysis.",
+              flush=True)
+    if args.min_aln_length > 0:
+        print(f"[INFO] --min-aln-length {args.min_aln_length}bp is ON: applied alongside "
+              f"every swept threshold combination.", flush=True)
+    if args.max_unaligned_length is not None:
+        print(f"[INFO] --max-unaligned-length {args.max_unaligned_length}bp is ON.", flush=True)
+    if identity_values != [0.0]:
+        print(f"[INFO] Identity sweep: {identity_values}", flush=True)
+    else:
+        print("[INFO] Identity sweep: off (all reads pass; set --identity-sweep to enable)", flush=True)
+    if match_qcov_values != [0.0]:
+        print(f"[INFO] Match-qcov sweep: {match_qcov_values}", flush=True)
+    else:
+        print("[INFO] Match-qcov sweep: off (all reads pass; set --match-qcov-sweep to enable)", flush=True)
+
+    total_seen, ref_lengths, n_excluded_by_snp = stream_primary_alignments_to_csv(
+        args.input, tmp_csv, args.min_mapq, args.exclude_snp_confirmation,
+        edge_aware_qcov=args.edge_aware_qcov
+    )
+    print(f"[INFO] {total_seen:,} primary mapped alignments seen "
+          f"(before any filtering)", flush=True)
+    if args.exclude_snp_confirmation:
+        print(f"[INFO] {n_excluded_by_snp:,} alignments excluded as "
+              f"RequiresSNPConfirmation (after --min-mapq, before query-coverage sweep)",
+              flush=True)
+
+    con = duckdb.connect(":memory:")
+    con.execute(f"CREATE TABLE aln AS SELECT * FROM read_csv('{tmp_csv}', header=true)")
+
+    baseline_n = con.execute("SELECT COUNT(*) FROM aln").fetchone()[0]
+    baseline_genes = con.execute("SELECT COUNT(DISTINCT gene_accession) FROM aln").fetchone()[0]
+
+    distinct_genes = [r[0] for r in con.execute("SELECT DISTINCT gene_accession FROM aln").fetchall()]
+    taxonomy_cache = {g: parse_gene_reference(g) for g in distinct_genes}
+
+    def distinct_taxonomy_count(idx: int) -> int:
+        return len({taxonomy_cache[g][idx] for g in distinct_genes if taxonomy_cache[g][idx]})
+
+    baseline_classes = distinct_taxonomy_count(2)
+    baseline_mechanisms = distinct_taxonomy_count(3)
+    baseline_groups = distinct_taxonomy_count(4)
+
+    print(f"[INFO] Baseline (--min-mapq {args.min_mapq}"
+          f"{', SNP-confirmation excluded' if args.exclude_snp_confirmation else ''}): "
+          f"{baseline_n:,} alignments, {baseline_genes:,} genes, "
+          f"{baseline_classes:,} classes, {baseline_mechanisms:,} mechanisms, "
+          f"{baseline_groups:,} groups\n", flush=True)
+
+    rows_out = []
+    gene_detail_rows = []
+    redundancy_rows = []
+    length_quantile_rows = []
+    baseline_fragment_hits: Optional[int] = None   # captured on the first (smallest) qcov below
+
+    QUANTILES_OVERALL = [5, 10, 25, 50, 75, 90, 95]
+
+    for qcov in qcov_values:
+      for identity in identity_values:
+       for match_qcov in match_qcov_values:
+        # Build the SQL WHERE clause. NULL handling for identity AND
+        # match_qcov: at threshold=0, reads missing the underlying NM tag
+        # pass (treated as unfiltered); at any positive threshold, NULL
+        # values are excluded — we can't verify them, so they shouldn't
+        # silently pass.
+        base_where = (
+            "qcov_pct >= ? AND aln_length >= ? "
+            "AND (? = 0 OR (pct_identity IS NOT NULL AND pct_identity >= ?)) "
+            "AND (? = 0 OR (match_qcov_pct IS NOT NULL AND match_qcov_pct >= ?))"
+        )
+        params_base = [qcov * 100.0, args.min_aln_length, identity, identity,
+                       match_qcov, match_qcov]
+
+        if args.max_unaligned_length is not None:
+            sub = con.execute(
+                "SELECT gene_accession, read_length, aln_length, base_read_id, "
+                f"COALESCE(pct_identity, 0.0) AS pct_identity, "
+                f"COALESCE(matched_length, 0) AS matched_length, blocks FROM aln "
+                f"WHERE {base_where} AND (read_length - aln_length) <= ?",
+                params_base + [args.max_unaligned_length],
+            ).fetchall()
+        else:
+            sub = con.execute(
+                "SELECT gene_accession, read_length, aln_length, base_read_id, "
+                f"COALESCE(pct_identity, 0.0) AS pct_identity, "
+                f"COALESCE(matched_length, 0) AS matched_length, blocks FROM aln WHERE {base_where}",
+                params_base,
+            ).fetchall()
+
+        n_retained = len(sub)
+        pct_retained = round(n_retained / baseline_n * 100, 2) if baseline_n else 0.0
+
+        gene_data: Dict[str, dict] = defaultdict(lambda: {
+            'intervals': [], 'read_lengths': [], 'aln_lengths': [],
+            'identities': [], 'matched_lengths': []
+        })
+        for gene, rl, al, base_id, pid, mlen, blocks_str in sub:
+            d = gene_data[gene]
+            for block in blocks_str.split(';'):
+                s_str, e_str = block.split(':')
+                d['intervals'].append((int(s_str), int(e_str)))
+            d['read_lengths'].append(rl)
+            d['aln_lengths'].append(al)
+            d['identities'].append(pid)
+            d['matched_lengths'].append(mlen)
+
+        gene_fragment_hits, discordant_diagnostics = resolve_fragment_hits(
+            [(gene, base_id, (mlen / rl * 100.0 if rl else 0.0))
+             for gene, rl, _, base_id, _, mlen, _ in sub],
+            taxonomy_cache=taxonomy_cache,
+            group_aware=args.group_aware,
+        )
+        n_fragment_hits_retained = sum(gene_fragment_hits.values())
+        if baseline_fragment_hits is None:
+            baseline_fragment_hits = n_fragment_hits_retained
+        pct_fragment_hits_retained = (
+            round(n_fragment_hits_retained / baseline_fragment_hits * 100, 2)
+            if baseline_fragment_hits else 0.0
+        )
+
+        gene_fraction_at_filter: Dict[str, float] = {}
+        gene_aln_count: Dict[str, int] = {}
+        for gene, d in gene_data.items():
+            length = ref_lengths.get(gene, 0)
+            covered = merged_interval_length(d['intervals'])
+            gene_fraction_at_filter[gene] = (covered / length) if length else 0.0
+            gene_aln_count[gene] = len(d['read_lengths'])
+
+        n_genes_at_filter = len(gene_fraction_at_filter)
+
+        threshold_labels = {
+            "min_query_coverage": qcov,
+            "min_identity": identity,
+            "min_match_qcov": match_qcov,
+        }
+
+        # ── redundancy and length-quantile outputs — written once per
+        # (qcov, identity, match_qcov), not once per gf (a downstream filter) ──
+        if args.redundancy_output:
+            redundancy_rows.extend(
+                compute_redundancy_table(threshold_labels, gene_data, gene_fragment_hits,
+                                         ref_lengths, taxonomy_cache)
+            )
+
+        if args.length_quantiles_output:
+            all_rl = sorted(rl for d in gene_data.values() for rl in d['read_lengths'])
+            all_al = sorted(al for d in gene_data.values() for al in d['aln_lengths'])
+            all_ml = sorted(ml for d in gene_data.values() for ml in d['matched_lengths'])
+            all_id = sorted(pid for d in gene_data.values() for pid in d['identities'])
+            # TRUE per-read match_qcov_pct quantiles: matched_lengths and
+            # read_lengths are parallel lists (same index = same read) within
+            # each gene's accumulator, so pairing them with zip() and dividing
+            # PER READ before taking quantiles is mathematically correct —
+            # unlike dividing matched_length_p{q} by read_length_p{q} (the
+            # quantile of a ratio is NOT the ratio of quantiles in general).
+            all_mq = sorted(
+                (ml / rl * 100.0 if rl else 0.0)
+                for d in gene_data.values()
+                for rl, ml in zip(d['read_lengths'], d['matched_lengths'])
+            )
+            qrow = {**threshold_labels, "n_alignments": len(all_rl)}
+            for q in QUANTILES_OVERALL:
+                qrow[f"read_length_p{q}"] = round(percentile(all_rl, q), 1)
+            for q in QUANTILES_OVERALL:
+                qrow[f"aln_length_p{q}"] = round(percentile(all_al, q), 1)
+            # matched_length: same as aln_length above but with mismatches/
+            # indels (NM) subtracted out — the "with vs without accounting
+            # for matches" comparison. Plot aln_length_p* and matched_length_p*
+            # side by side to see how much of the reported aligned length is
+            # actually composed of true matches vs noise.
+            for q in QUANTILES_OVERALL:
+                qrow[f"matched_length_p{q}"] = round(percentile(all_ml, q), 1)
+            for q in QUANTILES_OVERALL:
+                qrow[f"pct_identity_p{q}"] = round(percentile(all_id, q), 2)
+            for q in QUANTILES_OVERALL:
+                qrow[f"match_qcov_pct_p{q}"] = round(percentile(all_mq, q), 2)
+            length_quantile_rows.append(qrow)
+
+        if args.gene_detail_output:
+            for gene, frac in gene_fraction_at_filter.items():
+                d = gene_data[gene]
+                rl_sorted = sorted(d['read_lengths'])
+                al_sorted = sorted(d['aln_lengths'])
+                ml_sorted = sorted(d['matched_lengths'])
+                meg_id, gtype, gclass, mech, group, snp = taxonomy_cache.get(
+                    gene, (gene, '', '', '', '', '')
+                )
+                gene_detail_rows.append({
+                    **threshold_labels,
+                    "gene_accession": gene,
+                    "meg_id": meg_id, "type": gtype, "class": gclass,
+                    "mechanism": mech, "group": group, "snp": snp,
+                    "gene_length": ref_lengths.get(gene, 0),
+                    "covered_bases": merged_interval_length(d['intervals']),
+                    "gene_fraction": round(frac, 4),
+                    "read_count": gene_aln_count[gene],
+                    "n_fragment_hits": gene_fragment_hits.get(gene, 0),
+                    "pct_of_baseline_alignments": round(
+                        gene_aln_count[gene] / baseline_n * 100, 4) if baseline_n else 0.0,
+                    "identity_p10": round(percentile(sorted(d['identities']), 10), 2),
+                    "identity_median": round(percentile(sorted(d['identities']), 50), 2),
+                    "identity_p90": round(percentile(sorted(d['identities']), 90), 2),
+                    "read_length_p10": round(percentile(rl_sorted, 10), 1),
+                    "read_length_median": round(percentile(rl_sorted, 50), 1),
+                    "read_length_p90": round(percentile(rl_sorted, 90), 1),
+                    "aln_length_p10": round(percentile(al_sorted, 10), 1),
+                    "aln_length_median": round(percentile(al_sorted, 50), 1),
+                    "aln_length_p90": round(percentile(al_sorted, 90), 1),
+                    # matched_length: aln_length with mismatches/indels (NM)
+                    # subtracted — "alignment length accounting for only
+                    # matches." Compare against aln_length_p* above to see
+                    # how much of the reported alignment is genuine match
+                    # vs noise, per gene.
+                    "matched_length_p10": round(percentile(ml_sorted, 10), 1),
+                    "matched_length_median": round(percentile(ml_sorted, 50), 1),
+                    "matched_length_p90": round(percentile(ml_sorted, 90), 1),
+                })
+
+        # ── main grid: (qcov × identity × match_qcov × gf) ───────────────────
+        gf_group_summary = []  # (gf, n_groups_passing) — surfaced in the console line below,
+                                # since the per-threshold print previously only showed counts
+                                # from BEFORE the gf filter (n_genes_at_filter), making it look
+                                # like gene-fraction wasn't being swept at all even though it was.
+        for gf in gf_values:
+            passing_genes = [g for g, f in gene_fraction_at_filter.items() if f >= gf]
+            n_genes_passing = len(passing_genes)
+            pct_genes_passing = round(n_genes_passing / baseline_genes * 100, 2) if baseline_genes else 0.0
+
+            n_aln_in_passing_genes = sum(gene_aln_count[g] for g in passing_genes)
+            pct_aln_in_passing_genes = round(n_aln_in_passing_genes / baseline_n * 100, 2) if baseline_n else 0.0
+
+            n_hits_in_passing_genes = sum(gene_fragment_hits.get(g, 0) for g in passing_genes)
+            pct_hits_in_passing_genes = (
+                round(n_hits_in_passing_genes / baseline_fragment_hits * 100, 2)
+                if baseline_fragment_hits else 0.0
+            )
+
+            passing_classes    = {taxonomy_cache[g][2] for g in passing_genes if taxonomy_cache[g][2]}
+            passing_mechanisms = {taxonomy_cache[g][3] for g in passing_genes if taxonomy_cache[g][3]}
+            passing_groups     = {taxonomy_cache[g][4] for g in passing_genes if taxonomy_cache[g][4]}
+            gf_group_summary.append((gf, len(passing_groups)))
+
+            rows_out.append({
+                **threshold_labels,
+                "min_gene_fraction":                          gf,
+                "n_alignments_retained":                      n_retained,
+                "pct_alignments_retained_of_baseline":        pct_retained,
+                "n_alignments_in_passing_genes":              n_aln_in_passing_genes,
+                "pct_alignments_in_passing_genes_of_baseline": pct_aln_in_passing_genes,
+                "n_fragment_hits_retained":                   n_fragment_hits_retained,
+                "pct_fragment_hits_retained_of_baseline":     pct_fragment_hits_retained,
+                "n_fragment_hits_in_passing_genes":           n_hits_in_passing_genes,
+                "pct_fragment_hits_in_passing_genes_of_baseline": pct_hits_in_passing_genes,
+                "n_genes_at_filter":                          n_genes_at_filter,
+                "n_genes_passing_both":                       n_genes_passing,
+                "pct_genes_passing_of_baseline_genes":        pct_genes_passing,
+                "n_classes_passing":                          len(passing_classes),
+                "pct_classes_passing":  round(len(passing_classes)    / baseline_classes    * 100, 2) if baseline_classes    else 0.0,
+                "n_mechanisms_passing":                       len(passing_mechanisms),
+                "pct_mechanisms_passing": round(len(passing_mechanisms) / baseline_mechanisms * 100, 2) if baseline_mechanisms else 0.0,
+                "n_groups_passing":                           len(passing_groups),
+                "pct_groups_passing":   round(len(passing_groups)     / baseline_groups     * 100, 2) if baseline_groups     else 0.0,
+            })
+
+        gf_console_summary = " ".join(f"gf>={gf:.2g}:{n:,}grp" for gf, n in gf_group_summary)
+
+        discordant_suffix = ""
+        if args.group_aware:
+            n_same_group = discordant_diagnostics.get('same_group_diff_gene', 0)
+            n_cross_group = discordant_diagnostics.get('cross_group_both_counted', 0)
+            n_disagreeing = n_same_group + n_cross_group
+            discordant_suffix = (
+                f" | {n_disagreeing:,} disagreeing pairs "
+                f"({n_same_group:,} same-Group collapsed, {n_cross_group:,} cross-Group counted-both)"
+            )
+
+        print(f"  qcov>={qcov:.0%} identity>={identity:.0f}% match_qcov>={match_qcov:.0f}%: "
+              f"{n_retained:,} alignments ({pct_retained:.1f}% of baseline), "
+              f"{n_fragment_hits_retained:,} fragment hits ({pct_fragment_hits_retained:.1f}%), "
+              f"{n_genes_at_filter:,} genes detectable (pre-gf) | {gf_console_summary}{discordant_suffix}",
+              flush=True)
+
+    # ── write outputs ────────────────────────────────────────────────────────────
+    out_dir = os.path.dirname(args.output)
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
+    with open(args.output, "w", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=list(rows_out[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows_out)
+    print(f"\n[INFO] Wrote {len(rows_out)} grid rows to {args.output}", flush=True)
+    print("[INFO] Compare n_alignments_retained (qcov filter only) against "
+          "n_alignments_in_passing_genes (qcov + gene_fraction together) to see "
+          "how much alignment volume sits in genes with poor breadth.", flush=True)
+
+    if args.gene_detail_output and gene_detail_rows:
+        detail_dir = os.path.dirname(args.gene_detail_output)
+        if detail_dir:
+            os.makedirs(detail_dir, exist_ok=True)
+        with open(args.gene_detail_output, "w", newline="") as fh:
+            writer = csv.DictWriter(fh, fieldnames=list(gene_detail_rows[0].keys()))
+            writer.writeheader()
+            writer.writerows(gene_detail_rows)
+        print(f"[INFO] Wrote {len(gene_detail_rows):,} per-gene rows to {args.gene_detail_output}",
+              flush=True)
+        print("[INFO] Long tail: sort by read_count asc + gene_fraction asc. "
+              "Suspicious conserved-motif genes: sort by read_count DESC + gene_fraction asc.",
+              flush=True)
+
+    if args.redundancy_output and redundancy_rows:
+        red_dir = os.path.dirname(args.redundancy_output)
+        if red_dir:
+            os.makedirs(red_dir, exist_ok=True)
+        with open(args.redundancy_output, "w", newline="") as fh:
+            writer = csv.DictWriter(fh, fieldnames=list(redundancy_rows[0].keys()))
+            writer.writeheader()
+            writer.writerows(redundancy_rows)
+        print(f"[INFO] Wrote {len(redundancy_rows):,} group-redundancy rows to {args.redundancy_output}",
+              flush=True)
+
+        flagged = [r for r in redundancy_rows if r["min_query_coverage"] == qcov_values[0] and r["likely_redundant"]]
+        flagged.sort(key=lambda r: -r["n_accessions"])
+        if flagged:
+            print(f"[INFO] Top likely-redundant groups at qcov={qcov_values[0]:.0%} "
+                  f"(many near-identical accessions, no dominant single hit):", flush=True)
+            for r in flagged[:10]:
+                print(f"    {r['group']:<20} n_accessions={r['n_accessions']:<4} "
+                      f"total_reads={r['total_reads']:<6} "
+                      f"top_accession_share={r['pct_reads_in_top_accession']:.1f}% "
+                      f"length_cv={r['gene_length_cv']:.3f}", flush=True)
+
+    if args.length_quantiles_output and length_quantile_rows:
+        lq_dir = os.path.dirname(args.length_quantiles_output)
+        if lq_dir:
+            os.makedirs(lq_dir, exist_ok=True)
+        with open(args.length_quantiles_output, "w", newline="") as fh:
+            writer = csv.DictWriter(fh, fieldnames=list(length_quantile_rows[0].keys()))
+            writer.writeheader()
+            writer.writerows(length_quantile_rows)
+        print(f"[INFO] Wrote {len(length_quantile_rows)} length-quantile rows to "
+              f"{args.length_quantiles_output}", flush=True)
+
+    if not args.tmp_csv and not args.keep_tmp_csv:
+        os.remove(tmp_csv)
+    elif args.keep_tmp_csv:
+        print(f"[INFO] Intermediate per-alignment CSV kept at: {tmp_csv}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/kraken2_long_to_wide_parallel.py
+++ b/bin/kraken2_long_to_wide_parallel.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""
+Faster drop-in replacement for kraken2_long_to_wide.py
+Uses multiprocessing to parse report files in parallel.
+"""
+
+import sys
+import argparse
+import re
+import numpy as np
+from multiprocessing import Pool, cpu_count
+from collections import defaultdict
+
+taxa_levels = {'D':0,'K':1,'P':2,'C':3,'O':4,'F':5,'G':6,'S':7,'U':8}
+
+def parse_cmdline_params(args):
+    p = argparse.ArgumentParser()
+    p.add_argument('-i', '--input_files', nargs='+', required=True)
+    p.add_argument('-o', '--output_file', required=True)
+    p.add_argument('--merged', action='store_true')
+    p.add_argument('--threads', type=int, default=cpu_count())
+    return p.parse_args(args)
+
+
+def parse_one_report(file_path):
+    """Parse a single kraken report — runs in a worker process."""
+    sample_id = file_path.split('/')[-1].replace('.kraken.report', '')
+    counts = {}
+    unclassified = [0, 0, 0.0]
+    taxon_list = ['NA'] * 8
+    previous_level = 0
+
+    with open(file_path) as f:
+        for line in f:
+            line = line.rstrip('\n')
+            if not line:
+                continue
+            parts = line.split('\t')
+            if len(parts) < 6:
+                continue
+
+            node_count  = int(parts[2])
+            node_level  = parts[3].strip()
+            node_name   = parts[5].strip()
+
+            if node_level == 'U':
+                unclassified = [node_count, unclassified[1] + node_count, float(parts[0])]
+                continue
+            if node_level == 'R':
+                unclassified[1] += int(parts[1])
+                continue
+            if len(node_level) > 1:
+                if node_level[0] in ('U', 'R'):
+                    continue
+                parent = node_level[0]
+            else:
+                parent = node_level
+
+            if parent not in taxa_levels:
+                continue
+            this_level = taxa_levels[parent]
+
+            if len(node_level) == 1:
+                taxon_list[this_level] = node_name
+            if this_level < previous_level:
+                taxon_list[this_level + 1:] = ['NA'] * (7 - this_level)
+            previous_level = this_level
+
+            if node_count == 0:
+                continue
+
+            taxon_str = '|'.join(taxon_list[:this_level + 1])
+            counts[taxon_str] = counts.get(taxon_str, 0) + node_count
+
+    return sample_id, counts, unclassified
+
+
+def dict_to_matrix(counts_dict):
+    samples = list(counts_dict.keys())
+    all_taxa = list({t for c in counts_dict.values() for t in c})
+    taxa_idx = {t: i for i, t in enumerate(all_taxa)}
+    M = np.zeros((len(all_taxa), len(samples)), dtype=float)
+    for j, sid in enumerate(samples):
+        for taxon, cnt in counts_dict[sid].items():
+            M[taxa_idx[taxon], j] = cnt
+    return M, all_taxa, samples
+
+
+def write_output(outfile, M, taxa, samples, unclassifieds):
+    with open(outfile, 'w') as out:
+        out.write(','.join(['taxa'] + samples) + '\n')
+        for i, taxon in enumerate(taxa):
+            out.write(f'"{taxon.replace(",","")}",')
+            out.write(','.join(str(x) for x in M[i]) + '\n')
+
+    with open(f"unclassifieds_{outfile}", 'w') as u:
+        u.write('SampleID,NumberUnclassified,Total,PercentUnclassified\n')
+        for sid, nums in unclassifieds.items():
+            u.write(f"{sid},{','.join(str(x) for x in nums)}\n")
+
+
+if __name__ == '__main__':
+    opts = parse_cmdline_params(sys.argv[1:])
+
+    print(f"Parsing {len(opts.input_files)} files with {opts.threads} threads...",
+          file=sys.stderr)
+
+    with Pool(processes=opts.threads) as pool:
+        results = pool.map(parse_one_report, opts.input_files)
+
+    counts_dict = {sid: c for sid, c, _ in results}
+    uncls_dict  = {sid: u for sid, _, u in results}
+
+    M, taxa, samples = dict_to_matrix(counts_dict)
+    write_output(opts.output_file, M, taxa, samples, uncls_dict)
+    print(f"Done → {opts.output_file}", file=sys.stderr)

--- a/bin/plot_sweep_dropoff.R
+++ b/bin/plot_sweep_dropoff.R
@@ -1,0 +1,615 @@
+# ══════════════════════════════════════════════════════════════════════════════
+# Sweep Threshold Dropoff — Query-Coverage and Gene-Fraction
+# ══════════════════════════════════════════════════════════════════════════════
+#
+# Reads combined_gene_detail.csv / combined_results.csv / combined_length_quantiles.csv
+# (from combine_sweep_results.py). Each row carries a sample_id; there is no
+# workflow / read_subset grouping and no faceting — every plot is a single panel
+# showing the mean across samples (bold line) with each sample as a thin grey line.
+#
+# Usage:
+#   Rscript plot_sweep_dropoff.R
+#   Rscript plot_sweep_dropoff.R combined_sweep_results/ figures/
+# ══════════════════════════════════════════════════════════════════════════════
+
+suppressPackageStartupMessages({
+  library(data.table)
+  library(ggplot2)
+  library(scales)
+})
+setDTthreads(1)
+
+# ── arguments ─────────────────────────────────────────────────────────────────
+args    <- commandArgs(trailingOnly = TRUE)
+in_dir  <- if (length(args) >= 1) args[1] else "combined_sweep_results/"
+out_dir <- if (length(args) >= 2) args[2] else file.path(in_dir, "figures")
+dir.create(out_dir, recursive = TRUE, showWarnings = FALSE)
+
+gene_path <- file.path(in_dir, "combined_gene_detail.csv")
+if (!file.exists(gene_path)) stop("combined_gene_detail.csv not found in ", in_dir,
+                                  " — run combine_sweep_results.py first")
+
+LEVELS_TO_PLOT <- c("gene_accession", "class", "mechanism", "group")
+GF_SWEEP <- c(0, 0.1, 0.25, 0.5, 0.8)  # update to match --gene-fraction-sweep in bash
+
+message("Loading data...")
+genes <- fread(gene_path, showProgress = FALSE)
+genes <- genes[sample_id != "sample_id"]   # drop any embedded header rows
+
+qcov_values     <- sort(unique(as.double(genes$min_query_coverage)))
+identity_values <- if ("min_identity" %in% names(genes))
+  sort(unique(as.double(genes$min_identity))) else c(0)
+match_qcov_values <- if ("min_match_qcov" %in% names(genes))
+  sort(unique(as.double(genes$min_match_qcov))) else c(0)
+
+# Priority for "which axis is primary": match_qcov > identity > qcov.
+if (length(match_qcov_values) > 1) {
+  primary_values <- match_qcov_values
+  primary_col    <- "min_match_qcov"
+  primary_label  <- "Min match-qcov (%)"
+} else if (length(identity_values) > 1) {
+  primary_values <- identity_values
+  primary_col    <- "min_identity"
+  primary_label  <- "Min identity (%)"
+} else {
+  primary_values <- qcov_values
+  primary_col    <- "min_query_coverage"
+  primary_label  <- "Min query coverage"
+}
+PRIMARY_IS_IDENTITY <- primary_col %in% c("min_identity", "min_match_qcov")
+message(sprintf("  %s rows | %d samples",
+                formatC(nrow(genes), format = "d", big.mark = ","),
+                uniqueN(genes$sample_id)))
+message(sprintf("  Primary sweep: %s — values: %s",
+                primary_col, paste(primary_values, collapse = ", ")))
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Quick summary table (per-sample + averaged across samples)
+# ══════════════════════════════════════════════════════════════════════════════
+results_path <- file.path(in_dir, "combined_results.csv")
+if (file.exists(results_path)) {
+  message("\nBuilding quick summary table from combined_results.csv...")
+  results <- fread(results_path, showProgress = FALSE)
+  results <- results[sample_id != "sample_id"]
+  results[, n_fragment_hits_in_passing_genes := as.double(n_fragment_hits_in_passing_genes)]
+
+  THRESHOLD_COLS <- intersect(c("min_query_coverage", "min_identity",
+                                "min_match_qcov", "min_gene_fraction"),
+                              names(results))
+  message("  Threshold columns detected: ", paste(THRESHOLD_COLS, collapse = ", "))
+
+  raw_cols  <- c("n_alignments_in_passing_genes", "n_fragment_hits_in_passing_genes",
+                "n_genes_passing_both", "n_classes_passing",
+                "n_mechanisms_passing", "n_groups_passing")
+  new_names <- c("n_classified_alignments", "n_classified_fragment_hits",
+                "n_genes", "n_classes", "n_mechanisms", "n_groups")
+  present   <- raw_cols %in% names(results)
+  raw_cols  <- raw_cols[present]
+  new_names <- new_names[present]
+
+  id_cols <- c("sample_id", THRESHOLD_COLS)
+  per_sample_summary <- results[, ..id_cols]
+  for (i in seq_along(raw_cols)) per_sample_summary[[new_names[i]]] <- results[[raw_cols[i]]]
+
+  fwrite(per_sample_summary, file.path(out_dir, "summary_table_per_sample.csv"))
+  message(sprintf("  saved: summary_table_per_sample.csv (%s rows - one per sample x threshold combination)",
+                  formatC(nrow(per_sample_summary), format = "d", big.mark = ",")))
+
+  summary_table_avg <- per_sample_summary[, c(
+    lapply(.SD, mean), .(n_samples = .N)
+  ), by = THRESHOLD_COLS, .SDcols = new_names]
+  setnames(summary_table_avg, new_names, paste0("mean_", new_names))
+  setorderv(summary_table_avg, THRESHOLD_COLS)
+
+  fwrite(summary_table_avg, file.path(out_dir, "summary_table_averaged.csv"))
+  message(sprintf("  saved: summary_table_averaged.csv (%d rows - one per threshold combination, averaged across samples)",
+                  nrow(summary_table_avg)))
+  message("\nPreview of summary_table_averaged.csv:")
+  print(summary_table_avg)
+} else {
+  message("\n[NOTE] combined_results.csv not found in ", in_dir,
+         " - skipping quick summary table.")
+}
+
+show_plot <- function(p, stem, w = 9, h = 7) {
+  print(p)
+  ggsave(file.path(out_dir, paste0(stem, ".png")), p, width = w, height = h, dpi = 150)
+  message("  saved: ", stem, ".png")
+}
+
+# Combination-effect plot (single panel): x = retention, y = one threshold,
+# colour = the other threshold. Optional per-sample grey lines under the mean.
+make_combo_plot <- function(data, level, x_col, y_col, colour_col, colour_label,
+                            x_lab, y_lab, fname_stem, sample_data = NULL) {
+  p <- ggplot(data, aes(.data[[x_col]], .data[[y_col]],
+                       colour = factor(.data[[colour_col]])))
+  if (!is.null(sample_data)) {
+    p <- p + geom_line(
+      data = sample_data,
+      aes(x = .data[[x_col]], y = .data[[y_col]],
+          group = interaction(sample_id, .data[[colour_col]])),
+      colour = "grey70", alpha = 0.25, linewidth = 0.25, inherit.aes = FALSE
+    )
+  }
+  p <- p +
+    geom_line(linewidth = 0.9) + geom_point(size = 1.6) +
+    scale_y_continuous(labels = label_percent()) +
+    scale_colour_viridis_d(name = colour_label) +
+    labs(title    = paste0(toupper(substr(level,1,1)), substr(level,2,nchar(level)),
+                           " - combined effect of both thresholds"),
+         subtitle = if (!is.null(sample_data))
+           "Bold = mean across samples; grey = each individual sample"
+         else
+           "Each line holds the other threshold fixed at its labelled value",
+         x = x_lab, y = y_lab) +
+    theme_bw(base_size = 11) + theme(legend.position = "bottom")
+  p <- p + if (x_col == "mean_pct") {
+    scale_x_continuous(labels = label_comma(suffix = "%"), limits = c(0, 100))
+  } else {
+    scale_x_continuous(labels = label_comma())
+  }
+  show_plot(p, fname_stem)
+}
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Reads retained (single panel; mean line + per-sample grey lines)
+# ══════════════════════════════════════════════════════════════════════════════
+if (exists("results")) {
+  message("\nBuilding reads-retained figures from combined_results.csv...")
+
+  plot_reads_retained <- function(fixed_col, fixed_val, x_col, x_lab, fname_stem) {
+    sub <- results[get(fixed_col) == fixed_val]
+    value_cols <- c("pct_fragment_hits_in_passing_genes_of_baseline",
+                    "n_fragment_hits_in_passing_genes")
+    sub_long <- melt(sub, id.vars = c("sample_id", x_col), measure.vars = value_cols)
+    sub_long[, metric := factor(variable, levels = value_cols,
+                                labels = c("Mean % of baseline retained", "Mean absolute reads retained"))]
+
+    mean_data <- sub_long[, .(mean_val = mean(value)), by = c(x_col, "metric")]
+
+    p <- ggplot(mean_data, aes(.data[[x_col]] * 100, mean_val)) +
+      geom_line(data = sub_long, aes(x = .data[[x_col]] * 100, y = value, group = sample_id),
+               colour = "grey55", alpha = 0.35, linewidth = 0.3, inherit.aes = FALSE) +
+      geom_line(colour = "steelblue4", linewidth = 1) +
+      geom_point(colour = "steelblue4", size = 1.6) +
+      facet_wrap(~metric, scales = "free_y", ncol = 1) +
+      scale_x_continuous(breaks = seq(0, 100, 20), labels = label_percent(scale = 1)) +
+      scale_y_continuous(labels = label_comma()) +
+      labs(title = paste0("Fragment-hits retained vs ", x_lab, " - every sample (grey) + mean (blue)"),
+           x = x_lab, y = NULL) +
+      theme_bw(base_size = 10) +
+      theme(strip.background = element_rect(fill = "grey92"))
+    show_plot(p, fname_stem, h = 9)
+  }
+
+  plot_reads_retained("min_gene_fraction", min(GF_SWEEP),
+                      primary_col, primary_label, "reads_retained_vs_primary")
+  plot_reads_retained(primary_col, min(primary_values),
+                      "min_gene_fraction", "Min gene fraction", "reads_retained_vs_gf")
+
+  reads_grid <- results[, .(
+    mean_pct = mean(pct_fragment_hits_in_passing_genes_of_baseline),
+    mean_n   = mean(n_fragment_hits_in_passing_genes)
+  ), by = THRESHOLD_COLS]
+
+  fwrite(reads_grid, file.path(out_dir, "reads_retained_combined_grid.csv"))
+
+  reads_per_sample <- copy(results)
+  setnames(reads_per_sample,
+          c("pct_fragment_hits_in_passing_genes_of_baseline", "n_fragment_hits_in_passing_genes"),
+          c("mean_pct", "mean_n"))
+
+  p_reads_heat_pct <- ggplot(reads_grid, aes(factor(.data[[primary_col]]), factor(min_gene_fraction), fill = mean_pct)) +
+    geom_tile(colour = "white") +
+    geom_text(aes(label = paste0(round(mean_pct, 0), "%")), size = 2.8) +
+    scale_fill_distiller(palette = "RdYlBu", direction = 1, limits = c(0, 100), name = "% of\nbaseline") +
+    labs(title = "Fragment-hits retained - % of baseline (joint qcov x gene-fraction)",
+         x = primary_label, y = "Min gene fraction") +
+    theme_bw(base_size = 9) +
+    theme(axis.text.x = element_text(angle = 45, hjust = 1))
+  show_plot(p_reads_heat_pct, "reads_retained_combined_heatmap_pct")
+
+  p_reads_heat_count <- ggplot(reads_grid, aes(factor(.data[[primary_col]]), factor(min_gene_fraction), fill = mean_n)) +
+    geom_tile(colour = "white") +
+    geom_text(aes(label = round(mean_n, 0)), size = 2.8) +
+    scale_fill_distiller(palette = "RdYlBu", direction = 1, name = "Absolute\nreads") +
+    labs(title = "Fragment-hits retained - absolute count (joint qcov x gene-fraction)",
+         x = primary_label, y = "Min gene fraction") +
+    theme_bw(base_size = 9) +
+    theme(axis.text.x = element_text(angle = 45, hjust = 1))
+  show_plot(p_reads_heat_count, "reads_retained_combined_heatmap_count")
+
+  make_combo_plot(reads_grid, "reads", "mean_pct", primary_col, "min_gene_fraction",
+                  "Gene\nfraction", "Mean % of baseline retained", primary_label,
+                  "reads_retained_combo_by_primary_pct", sample_data = reads_per_sample)
+  make_combo_plot(reads_grid, "reads", "mean_n", primary_col, "min_gene_fraction",
+                  "Gene\nfraction", "Mean absolute reads retained", primary_label,
+                  "reads_retained_combo_by_primary_count", sample_data = reads_per_sample)
+  make_combo_plot(reads_grid, "reads", "mean_pct", "min_gene_fraction", primary_col,
+                  gsub("\n", " ", primary_label), "Mean % of baseline retained", "Min gene fraction",
+                  "reads_retained_combo_by_gf_pct", sample_data = reads_per_sample)
+  make_combo_plot(reads_grid, "reads", "mean_n", "min_gene_fraction", primary_col,
+                  gsub("\n", " ", primary_label), "Mean absolute reads retained", "Min gene fraction",
+                  "reads_retained_combo_by_gf_count", sample_data = reads_per_sample)
+
+  baseline_per_sample <- results[
+    get(primary_col) == min(primary_values) & min_gene_fraction == min(GF_SWEEP),
+    .(sample_id, baseline_hits = n_fragment_hits_in_passing_genes)
+  ]
+  results_lost <- merge(results, baseline_per_sample, by = "sample_id")
+  results_lost[, n_hits_lost   := baseline_hits - n_fragment_hits_in_passing_genes]
+  results_lost[, pct_hits_lost := as.double(100 - pct_fragment_hits_in_passing_genes_of_baseline)]
+  results_lost[, n_hits_lost   := as.double(n_hits_lost)]
+
+  plot_reads_lost <- function(fixed_col, fixed_val, x_col, x_lab, fname_stem) {
+    sub <- results_lost[get(fixed_col) == fixed_val]
+    value_cols <- c("pct_hits_lost", "n_hits_lost")
+    sub_long <- melt(sub, id.vars = c("sample_id", x_col), measure.vars = value_cols)
+    sub_long[, metric := factor(variable, levels = value_cols,
+                                labels = c("Mean % of baseline LOST", "Mean absolute reads LOST"))]
+
+    mean_data <- sub_long[, .(mean_val = mean(value)), by = c(x_col, "metric")]
+
+    p <- ggplot(mean_data, aes(.data[[x_col]] * 100, mean_val)) +
+      geom_line(data = sub_long, aes(x = .data[[x_col]] * 100, y = value, group = sample_id),
+               colour = "grey55", alpha = 0.35, linewidth = 0.3, inherit.aes = FALSE) +
+      geom_line(colour = "firebrick", linewidth = 1) +
+      geom_point(colour = "firebrick", size = 1.6) +
+      facet_wrap(~metric, scales = "free_y", ncol = 1) +
+      scale_x_continuous(breaks = seq(0, 100, 20), labels = label_percent(scale = 1)) +
+      scale_y_continuous(labels = label_comma()) +
+      labs(title = paste0("Fragment-hits LOST vs ", x_lab, " - every sample (grey) + mean (red)"),
+           subtitle = "Complement of the retained figures; baseline = count at no-filter (qcov=0, gf=0)",
+           x = x_lab, y = NULL) +
+      theme_bw(base_size = 10) +
+      theme(strip.background = element_rect(fill = "grey92"))
+    show_plot(p, fname_stem, h = 9)
+  }
+
+  plot_reads_lost("min_gene_fraction", min(GF_SWEEP),
+                  primary_col, primary_label, "reads_lost_vs_primary")
+  plot_reads_lost(primary_col, min(primary_values),
+                  "min_gene_fraction", "Min gene fraction", "reads_lost_vs_gf")
+}
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Percent identity + alignment-length distributions (single panel each)
+# ══════════════════════════════════════════════════════════════════════════════
+quant_path <- file.path(in_dir, "combined_length_quantiles.csv")
+if (file.exists(quant_path)) {
+  message("\nBuilding identity and alignment-length figures from combined_length_quantiles.csv...")
+  quant <- fread(quant_path, showProgress = FALSE)
+  quant <- quant[sample_id != "sample_id"]
+
+  id_cols_present <- grep("^pct_identity_p", names(quant), value = TRUE)
+  if (length(id_cols_present) == 0) {
+    message("  [NOTE] No pct_identity_p* columns found in combined_length_quantiles.csv.")
+  } else {
+    quant[, (id_cols_present) := lapply(.SD, as.double), .SDcols = id_cols_present]
+    quant[, min_query_coverage := as.double(min_query_coverage)]
+
+    quant_mq_vals  <- if ("min_match_qcov" %in% names(quant)) sort(unique(as.double(quant$min_match_qcov))) else c(0)
+    quant_id_vals  <- if ("min_identity"   %in% names(quant)) sort(unique(as.double(quant$min_identity)))   else c(0)
+    quant_primary_col <- if (length(quant_mq_vals) > 1) "min_match_qcov" else
+                         if (length(quant_id_vals) > 1) "min_identity" else
+                         "min_query_coverage"
+    quant_primary_label <- switch(quant_primary_col,
+      min_match_qcov     = "Min match-qcov (%)",
+      min_identity        = "Min identity (%)",
+      min_query_coverage  = "Min query coverage (%)")
+    quant[, quant_primary := as.double(get(quant_primary_col))]
+
+    # ── Figure 1: identity distribution vs the primary threshold ───────────
+    id_summary <- quant[, .(
+      p10  = mean(as.double(pct_identity_p10)),
+      p25  = mean(as.double(pct_identity_p25)),
+      p50  = mean(as.double(pct_identity_p50)),
+      p75  = mean(as.double(pct_identity_p75)),
+      p90  = mean(as.double(pct_identity_p90)),
+      p5   = mean(as.double(pct_identity_p5)),
+      p95  = mean(as.double(pct_identity_p95))
+    ), by = .(quant_primary)]
+
+    sample_median <- quant[, .(median_identity = mean(as.double(pct_identity_p50))),
+                          by = .(sample_id, quant_primary)]
+
+    p_id_dist <- ggplot(id_summary, aes(x = factor(round(quant_primary, 0)))) +
+      geom_errorbar(aes(ymin = p5, ymax = p95), width = 0.2, colour = "grey40") +
+      geom_crossbar(aes(y = p50, ymin = p25, ymax = p75),
+                    fill = "steelblue4", alpha = 0.7, colour = "steelblue4", width = 0.5) +
+      geom_line(data = sample_median,
+               aes(x = factor(round(quant_primary, 0)),
+                   y = median_identity, group = sample_id),
+               colour = "grey70", alpha = 0.3, linewidth = 0.25, inherit.aes = FALSE) +
+      geom_point(aes(y = p50), colour = "white", size = 2) +
+      scale_y_continuous(limits = c(0, 100), breaks = seq(0, 100, 20),
+                         labels = label_percent(scale = 1)) +
+      labs(title = paste0("Percent identity distribution vs ", quant_primary_label),
+           subtitle = paste0("Box = IQR (p25-p75), whiskers = p5-p95, white dot = mean median,",
+                             " grey lines = per-sample median.\n",
+                             "Identity = (aln_length - NM) / aln_length; based on NM edit-distance tag."),
+           x = quant_primary_label, y = "Percent identity across aligned region") +
+      theme_bw(base_size = 10)
+    show_plot(p_id_dist, "identity_distribution_vs_primary", h = 7, w = 10)
+
+    # ── Figure 2: alignment length, WITH and WITHOUT accounting for matches ─
+    ml_cols_present <- grep("^matched_length_p", names(quant), value = TRUE)
+    if (length(ml_cols_present) == 0) {
+      message("  [NOTE] No matched_length_p* columns found — skipping length comparison.")
+    } else {
+      quant[, (ml_cols_present) := lapply(.SD, as.double), .SDcols = ml_cols_present]
+      al_cols_present <- grep("^aln_length_p", names(quant), value = TRUE)
+      quant[, (al_cols_present) := lapply(.SD, as.double), .SDcols = al_cols_present]
+
+      len_summary <- quant[, .(
+        raw_p25 = mean(aln_length_p25), raw_p50 = mean(aln_length_p50), raw_p75 = mean(aln_length_p75),
+        raw_p5  = mean(aln_length_p5),  raw_p95 = mean(aln_length_p95),
+        match_p25 = mean(matched_length_p25), match_p50 = mean(matched_length_p50), match_p75 = mean(matched_length_p75),
+        match_p5  = mean(matched_length_p5),  match_p95 = mean(matched_length_p95)
+      ), by = .(quant_primary)]
+
+      len_long <- rbindlist(list(
+        len_summary[, .(quant_primary, length_type = "Raw aligned length (incl. mismatches/indels)",
+                        p5 = raw_p5, p25 = raw_p25, p50 = raw_p50, p75 = raw_p75, p95 = raw_p95)],
+        len_summary[, .(quant_primary, length_type = "Matched-only length (true matches)",
+                        p5 = match_p5, p25 = match_p25, p50 = match_p50, p75 = match_p75, p95 = match_p95)]
+      ))
+
+      p_len_dist <- ggplot(len_long, aes(x = factor(round(quant_primary, 0)),
+                                         colour = length_type, fill = length_type)) +
+        geom_errorbar(aes(ymin = p5, ymax = p95), width = 0.2,
+                     position = position_dodge(width = 0.6)) +
+        geom_crossbar(aes(y = p50, ymin = p25, ymax = p75), alpha = 0.6, width = 0.5,
+                     position = position_dodge(width = 0.6)) +
+        scale_colour_manual(values = c("Raw aligned length (incl. mismatches/indels)" = "grey40",
+                                       "Matched-only length (true matches)" = "steelblue4")) +
+        scale_fill_manual(values = c("Raw aligned length (incl. mismatches/indels)" = "grey70",
+                                     "Matched-only length (true matches)" = "steelblue4")) +
+        scale_y_continuous(labels = label_comma()) +
+        labs(title = paste0("Alignment length vs ", quant_primary_label, " - with and without accounting for matches"),
+             subtitle = paste0("Box = IQR (p25-p75), whiskers = p5-p95, across samples.\n",
+                               "Matched-only length = aln_length - NM (mismatches/indels subtracted via the NM edit-distance tag)."),
+             x = quant_primary_label, y = "Length (bp)", colour = NULL, fill = NULL) +
+        theme_bw(base_size = 10) + theme(legend.position = "bottom")
+      show_plot(p_len_dist, "alignment_length_with_vs_without_matches", h = 7, w = 10)
+
+      fwrite(len_summary, file.path(out_dir, "alignment_length_quantile_summary.csv"))
+      message("  saved: alignment_length_quantile_summary.csv")
+    }
+
+    # ── Figure 3: identity quantile heatmap ─────────────────────────────────
+    quant_long <- melt(id_summary,
+                       id.vars     = c("quant_primary"),
+                       measure.vars = c("p5", "p10", "p25", "p50", "p75", "p90", "p95"),
+                       variable.name = "quantile", value.name = "mean_identity")
+
+    p_id_heat <- ggplot(quant_long,
+                        aes(factor(quantile, levels = c("p5","p10","p25","p50","p75","p90","p95")),
+                            factor(round(quant_primary, 0)),
+                            fill = mean_identity)) +
+      geom_tile(colour = "white") +
+      geom_text(aes(label = round(mean_identity, 1)), size = 2.6) +
+      scale_fill_distiller(palette = "RdYlBu", direction = 1,
+                           limits = c(50, 100), name = "Mean\nidentity (%)") +
+      labs(title = paste0("Mean percent identity quantiles by ", quant_primary_label),
+           subtitle = "Each cell = mean across samples of that quantile of the identity distribution",
+           x = "Identity quantile", y = quant_primary_label) +
+      theme_bw(base_size = 9)
+    show_plot(p_id_heat, "identity_quantile_heatmap", w = 10)
+
+    fwrite(id_summary, file.path(out_dir, "identity_quantile_summary.csv"))
+    message("  saved: identity_quantile_summary.csv")
+
+    # ── Figures 4-6: BASELINE (zero-filter) distribution histograms ────────────
+    QLEVELS_HIST  <- c(5, 10, 25, 50, 75, 90, 95)
+    INTERVAL_MASS <- c(5, 15, 25, 25, 15,  5)
+    TRUE_MASS     <- 0.90
+    N_PTS         <- 2000
+
+    reconstruct <- function(qvals, n) {
+      qvals <- as.numeric(qvals)
+      if (any(is.na(qvals)) || length(qvals) != 7) return(numeric(0))
+      pts <- list()
+      for (i in 1:6) {
+        ni <- round(n * INTERVAL_MASS[i] / 90)
+        lo <- qvals[i]; hi <- qvals[i + 1]
+        if (hi < lo) hi <- lo
+        pts[[i]] <- if (ni > 0) runif(ni, lo, hi) else numeric(0)
+      }
+      unlist(pts)
+    }
+
+    build_pts <- function(data, prefix) {
+      qcols <- paste0(prefix, "_p", QLEVELS_HIST)
+      if (!all(qcols %in% names(data))) return(NULL)
+      rbindlist(lapply(seq_len(nrow(data)), function(i) {
+        pts <- reconstruct(as.numeric(data[i, ..qcols]), N_PTS)
+        if (length(pts) == 0) return(NULL)
+        data.table(value = pts)
+      }))
+    }
+
+    density_hist_plot <- function(pts_dt, x_lab, title, fname, binwidth, xlim = NULL) {
+      if (is.null(pts_dt) || nrow(pts_dt) == 0) {
+        message("  [SKIP] No data to plot for ", fname); return(invisible(NULL))
+      }
+      v <- pts_dt$value
+      lo_b <- floor(min(v) / binwidth) * binwidth
+      hi_b <- ceiling(max(v) / binwidth) * binwidth + binwidth
+      brks <- seq(lo_b, hi_b, by = binwidth)
+      h <- hist(v, breaks = brks, plot = FALSE)
+      hist_dt <- data.table(mid = h$mids, density = h$counts / length(v) * TRUE_MASS / binwidth)
+      d <- density(v); dens_dt <- data.table(x = d$x, y = d$y * TRUE_MASS)
+
+      p <- ggplot() +
+        geom_col(data = hist_dt, aes(mid, density), width = binwidth,
+                fill = "steelblue4", colour = "white", alpha = 0.8) +
+        geom_line(data = dens_dt, aes(x, y), colour = "firebrick", linewidth = 0.7) +
+        { if (!is.null(xlim)) coord_cartesian(xlim = xlim) } +
+        labs(title = title,
+             subtitle = paste0("Baseline (zero-filter) distribution reconstructed from per-sample quantiles ",
+                               "(p5-p95; shaded area = ", TRUE_MASS,
+                               "; outer 5% tails on each side not shown).\n",
+                               uniqueN(pts_dt), " pooled sample-rows."),
+             x = x_lab,
+             y = paste0("Density (integrates to ~", TRUE_MASS,
+                        " over shown range; remaining ", 1 - TRUE_MASS, " in unshown tails)")) +
+        theme_bw(base_size = 10)
+      show_plot(p, fname, h = 6, w = 9)
+    }
+
+    quant_thresh_cols <- intersect(c("min_query_coverage", "min_identity",
+                                     "min_match_qcov"), names(quant))
+    for (col in quant_thresh_cols) quant[, (col) := as.double(get(col))]
+    quant_baseline <- quant[Reduce(`&`, lapply(quant_thresh_cols, function(c) get(c) == 0))]
+    message("  Baseline (zero-filter) rows for histograms: ", nrow(quant_baseline))
+
+    if (nrow(quant_baseline) > 0) {
+      rl_pts <- build_pts(quant_baseline, "read_length")
+      rl_range <- if (!is.null(rl_pts)) diff(range(rl_pts$value)) else 0
+      rl_bw <- max(1, round(rl_range / 40))
+      density_hist_plot(rl_pts, "Read length (bp)",
+                        "Baseline read-length distribution",
+                        "baseline_read_length_histogram", binwidth = rl_bw)
+
+      density_hist_plot(build_pts(quant_baseline, "aln_length"),
+                        "Aligned length (bp)  [clipping-only, includes mismatches/indels]",
+                        "Baseline aligned-length distribution",
+                        "baseline_aln_length_histogram", binwidth = rl_bw)
+
+      ml_cols_hist <- paste0("matched_length_p", QLEVELS_HIST)
+      if (all(ml_cols_hist %in% names(quant_baseline))) {
+        density_hist_plot(build_pts(quant_baseline, "matched_length"),
+                          "Matched length (bp)  [aln_length - NM; true matches only]",
+                          "Baseline matched-length distribution (matches only)",
+                          "baseline_matched_length_histogram", binwidth = rl_bw)
+      }
+
+      mq_exact <- paste0("match_qcov_pct_p", QLEVELS_HIST)
+      if (all(mq_exact %in% names(quant_baseline))) {
+        mq_pts <- build_pts(quant_baseline, "match_qcov_pct")
+        mq_title_sfx <- ""
+      } else if (all(c(ml_cols_hist, paste0("read_length_p", QLEVELS_HIST)) %in% names(quant_baseline))) {
+        message("  [APPROX] match_qcov_pct_p* absent — approximating as matched_length_p{q}/read_length_p{q}")
+        approx_mq <- copy(quant_baseline)
+        mq_out_cols <- paste0("match_qcov_pct_p", QLEVELS_HIST)
+        for (q in QLEVELS_HIST) {
+          ml_c <- paste0("matched_length_p", q); rl_c <- paste0("read_length_p", q)
+          approx_mq[, paste0("match_qcov_pct_p", q) := get(ml_c) / get(rl_c) * 100]
+        }
+        for (i in seq_len(nrow(approx_mq))) {
+          v <- cummax(as.numeric(approx_mq[i, ..mq_out_cols]))
+          approx_mq[i, (mq_out_cols) := as.list(v)]
+        }
+        mq_pts   <- build_pts(approx_mq, "match_qcov_pct")
+        mq_title_sfx <- " [approximate]"
+      } else {
+        mq_pts <- NULL; mq_title_sfx <- ""
+      }
+      density_hist_plot(mq_pts,
+                        "Match-query percentage (%)  [(matched_length / read_length) x 100]",
+                        paste0("Baseline match-query-% distribution", mq_title_sfx),
+                        "baseline_match_qcov_pct_histogram", binwidth = 2.5, xlim = c(0, 100))
+    }
+  }
+} else {
+  message("\n[NOTE] combined_length_quantiles.csv not found in ", in_dir, " — skipping identity/length figures.")
+}
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Per-level dropoff: derive counts at each (primary x gene-fraction) from raw
+# gene_detail, for each annotation level. Single panel per plot.
+# ══════════════════════════════════════════════════════════════════════════════
+message("\nBuilding per-level dropoff figures from combined_gene_detail.csv...")
+
+# numeric coercions
+num_cols <- intersect(c("min_query_coverage", "min_identity", "min_match_qcov",
+                        "gene_fraction", "read_count"), names(genes))
+for (col in num_cols) genes[, (col) := as.double(get(col))]
+
+# the primary sweep column present in gene_detail
+gd_primary_col <- if ("min_match_qcov" %in% names(genes) && length(match_qcov_values) > 1) "min_match_qcov" else
+                  if ("min_identity"   %in% names(genes) && length(identity_values)   > 1) "min_identity"   else
+                  "min_query_coverage"
+
+level_available <- LEVELS_TO_PLOT[LEVELS_TO_PLOT %in% names(genes)]
+if (length(level_available) == 0) {
+  message("  [NOTE] none of ", paste(LEVELS_TO_PLOT, collapse = ", "),
+          " are columns in gene_detail — skipping per-level dropoff.")
+}
+
+for (level in level_available) {
+  message("  level: ", level)
+
+  # For each (sample, primary, gene_fraction cutoff), count distinct level entities
+  # whose gene_fraction >= cutoff. Build across the GF_SWEEP grid.
+  level_rows <- rbindlist(lapply(GF_SWEEP, function(gf) {
+    passed <- genes[gene_fraction >= gf]
+    cnt <- passed[, .(n_entities = uniqueN(get(level))),
+                  by = c("sample_id", gd_primary_col)]
+    cnt[, min_gene_fraction := gf]
+    cnt
+  }))
+  if (nrow(level_rows) == 0) next
+
+  # baseline per sample = count at (min primary, min gf)
+  base <- level_rows[get(gd_primary_col) == min(primary_values) &
+                       min_gene_fraction == min(GF_SWEEP),
+                     .(sample_id, baseline_n = n_entities)]
+  level_rows <- merge(level_rows, base, by = "sample_id", all.x = TRUE)
+  level_rows[, pct_of_baseline := ifelse(baseline_n > 0, n_entities / baseline_n * 100, NA_real_)]
+
+  # mean across samples
+  level_mean <- level_rows[, .(mean_n = mean(n_entities),
+                               mean_pct = mean(pct_of_baseline, na.rm = TRUE)),
+                           by = c(gd_primary_col, "min_gene_fraction")]
+
+  # ── Dropoff curve: x = primary, y = mean count, colour = gene fraction ──
+  p1 <- ggplot(level_mean, aes(.data[[gd_primary_col]] * (if (PRIMARY_IS_IDENTITY) 1 else 100),
+                               mean_n, colour = factor(min_gene_fraction))) +
+    geom_line(data = level_rows,
+             aes(x = .data[[gd_primary_col]] * (if (PRIMARY_IS_IDENTITY) 1 else 100),
+                 y = n_entities,
+                 group = interaction(sample_id, min_gene_fraction)),
+             colour = "grey75", alpha = 0.2, linewidth = 0.25, inherit.aes = FALSE) +
+    geom_line(linewidth = 0.9) + geom_point(size = 1.5) +
+    scale_colour_viridis_d(name = "Min gene\nfraction") +
+    scale_x_continuous(labels = if (PRIMARY_IS_IDENTITY) label_comma() else label_percent(scale = 1)) +
+    scale_y_continuous(labels = label_comma()) +
+    labs(title = paste0(toupper(substr(level,1,1)), substr(level,2,nchar(level)),
+                        " count vs ", primary_label),
+         subtitle = "Bold = mean across samples; grey = each sample",
+         x = primary_label, y = paste0("Distinct ", level, " count")) +
+    theme_bw(base_size = 11) + theme(legend.position = "bottom")
+  show_plot(p1, paste0("dropoff_", level, "_count_vs_primary"))
+
+  # ── % of baseline version ──
+  p2 <- ggplot(level_mean, aes(.data[[gd_primary_col]] * (if (PRIMARY_IS_IDENTITY) 1 else 100),
+                               mean_pct, colour = factor(min_gene_fraction))) +
+    geom_line(linewidth = 0.9) + geom_point(size = 1.5) +
+    scale_colour_viridis_d(name = "Min gene\nfraction") +
+    scale_x_continuous(labels = if (PRIMARY_IS_IDENTITY) label_comma() else label_percent(scale = 1)) +
+    scale_y_continuous(labels = label_percent(scale = 1), limits = c(0, NA)) +
+    labs(title = paste0(toupper(substr(level,1,1)), substr(level,2,nchar(level)),
+                        " retained (% of baseline) vs ", primary_label),
+         x = primary_label, y = "% of baseline retained") +
+    theme_bw(base_size = 11) + theme(legend.position = "bottom")
+  show_plot(p2, paste0("dropoff_", level, "_pct_vs_primary"))
+
+  # ── Heatmap: primary x gene fraction, fill = mean count ──
+  p3 <- ggplot(level_mean, aes(factor(round(get(gd_primary_col), 3)),
+                               factor(min_gene_fraction), fill = mean_n)) +
+    geom_tile(colour = "white") +
+    geom_text(aes(label = round(mean_n, 0)), size = 2.8) +
+    scale_fill_distiller(palette = "RdYlBu", direction = 1, name = paste0("Mean\n", level, "\ncount")) +
+    labs(title = paste0(toupper(substr(level,1,1)), substr(level,2,nchar(level)),
+                        " count - joint threshold heatmap"),
+         x = primary_label, y = "Min gene fraction") +
+    theme_bw(base_size = 9) +
+    theme(axis.text.x = element_text(angle = 45, hjust = 1))
+  show_plot(p3, paste0("dropoff_", level, "_heatmap"))
+
+  fwrite(level_mean, file.path(out_dir, paste0("dropoff_", level, "_summary.csv")))
+}
+
+message("\nDone. Figures + summary CSVs written to: ", out_dir)

--- a/bin/summarize_read_stats.py
+++ b/bin/summarize_read_stats.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""
+summarize_read_stats.py
+
+Combine per-step seqkit stats into a single tidy spreadsheet with one row per
+(sample, step, read-type). Handles single-end, paired-end, and merged+unmerged
+layouts by inferring the read-type from each filename.
+
+Typical use inside AMR++: each pipeline step (Raw, QC_trimmed, Deduped,
+NonHost, ...) runs `seqkit stats -T -a` on its FASTQs and writes a
+`<step>_seqkit.tsv`. This script is then run once on all of those to emit the
+final combined workbook / CSV.
+
+Output is a plain CSV (openpyxl / any spreadsheet library intentionally NOT used —
+stdlib only, so it runs in any environment without extra dependencies). The CSV opens
+directly in Excel / LibreOffice / Google Sheets.
+
+Usage
+-----
+    # Combine several per-step seqkit tables:
+    python summarize_read_stats.py \
+        -i Raw_seqkit.tsv QC_trimmed_seqkit.tsv Deduped_seqkit.tsv NonHost_seqkit.tsv \
+        -o read_stats_summary.csv
+"""
+
+import argparse
+import os
+import re
+import sys
+from collections import OrderedDict
+
+
+# ── Read-type inference ──────────────────────────────────────────────────────
+# Ordered: first pattern that matches a filename wins. Tweak here if your
+# naming ever changes rather than touching the logic below.
+READ_TYPE_PATTERNS = [
+    (re.compile(r'\.extendedFrags\b|\bmerged\b(?!.*unmerged)', re.I), 'merged'),
+    (re.compile(r'\.notCombined\b|\bunmerged\b',               re.I), 'unmerged'),
+    (re.compile(r'_R1\b|\.1P\b|_1\b|\bR1\b',                    re.I), 'R1'),
+    (re.compile(r'_R2\b|\.2P\b|_2\b|\bR2\b',                    re.I), 'R2'),
+]
+
+
+def infer_read_type(filename):
+    """Return 'merged'|'unmerged'|'R1'|'R2'|'single' for a FASTQ filename."""
+    base = os.path.basename(filename)
+    for pattern, label in READ_TYPE_PATTERNS:
+        if pattern.search(base):
+            return label
+    return 'single'
+
+
+def infer_sample_id(filename):
+    """
+    Strip directory, common FASTQ extensions, read-type tags, and step tags
+    to recover a stable sample id that is consistent across R1/R2/merged/etc.
+    """
+    base = os.path.basename(filename)
+    # strip extensions
+    base = re.sub(r'\.(fastq|fq)(\.gz)?$', '', base, flags=re.I)
+    # strip read-type / pairing tags
+    base = re.sub(r'(\.extendedFrags|\.notCombined)', '', base, flags=re.I)
+    base = re.sub(r'([._-])(merged|unmerged)\b', '', base, flags=re.I)
+    base = re.sub(r'([._-])(R?[12]P?)\b', '', base, flags=re.I)
+    # strip common per-step suffixes so the same sample lines up across steps
+    base = re.sub(r'\.(trimmed|dedup|non\.host|nonhost|host)\b', '', base, flags=re.I)
+    return base
+
+
+# ── seqkit table parsing ─────────────────────────────────────────────────────
+def parse_seqkit_table(path, step_label):
+    """
+    Parse one `seqkit stats -T` (tab-separated) file.
+    Returns a list of row dicts, one per input FASTQ line.
+    """
+    rows = []
+    with open(path) as fh:
+        header = fh.readline().rstrip('\n').split('\t')
+        # seqkit -T columns: file format type num_seqs sum_len min_len avg_len max_len ...
+        idx = {name: i for i, name in enumerate(header)}
+
+        def col(parts, name, cast=str, default=''):
+            if name in idx and idx[name] < len(parts):
+                val = parts[idx[name]]
+                try:
+                    return cast(val)
+                except (ValueError, TypeError):
+                    return default
+            return default
+
+        for line in fh:
+            line = line.rstrip('\n')
+            if not line:
+                continue
+            parts = line.split('\t')
+            fpath = col(parts, 'file')
+            rows.append(OrderedDict([
+                ('sample_id',  infer_sample_id(fpath)),
+                ('step',       step_label),
+                ('read_type',  infer_read_type(fpath)),
+                ('num_reads',  col(parts, 'num_seqs', lambda x: int(float(x)), 0)),
+                ('total_bp',   col(parts, 'sum_len',  lambda x: int(float(x)), 0)),
+                ('min_len',    col(parts, 'min_len',  lambda x: int(float(x)), 0)),
+                ('avg_len',    col(parts, 'avg_len',  float, 0.0)),
+                ('max_len',    col(parts, 'max_len',  lambda x: int(float(x)), 0)),
+                ('file',       os.path.basename(fpath)),
+            ]))
+    return rows
+
+
+def step_label_from_filename(path):
+    """Derive a step label from a '<step>_seqkit.tsv' filename."""
+    base = os.path.basename(path)
+    base = re.sub(r'_seqkit\.tsv$', '', base, flags=re.I)
+    base = re.sub(r'\.(tsv|txt|csv)$', '', base, flags=re.I)
+    return base or 'unknown'
+
+
+# ── Aggregation: add per-sample merged+unmerged rollup ───────────────────────
+def add_pair_rollups(rows):
+    """
+    For samples that have both 'merged' and 'unmerged' rows within a step,
+    add a synthetic 'combined' row summing their read counts — so the
+    spreadsheet has an at-a-glance total for merged-pipeline samples.
+    """
+    # index existing (sample, step, read_type)
+    grouped = {}
+    for r in rows:
+        grouped.setdefault((r['sample_id'], r['step']), {})[r['read_type']] = r
+
+    extra = []
+    for (sample, step), by_type in grouped.items():
+        if 'merged' in by_type and 'unmerged' in by_type:
+            m, u = by_type['merged'], by_type['unmerged']
+            extra.append(OrderedDict([
+                ('sample_id', sample),
+                ('step',      step),
+                ('read_type', 'merged+unmerged (combined)'),
+                ('num_reads', m['num_reads'] + u['num_reads']),
+                ('total_bp',  m['total_bp']  + u['total_bp']),
+                ('min_len',   min(m['min_len'], u['min_len'])),
+                ('avg_len',   ''),   # avg not meaningful across two pools
+                ('max_len',   max(m['max_len'], u['max_len'])),
+                ('file',      ''),
+            ]))
+    return rows + extra
+
+
+# ── Output writers ───────────────────────────────────────────────────────────
+def write_csv(rows, out_path):
+    import csv
+    fieldnames = ['sample_id', 'step', 'read_type', 'num_reads',
+                  'total_bp', 'min_len', 'avg_len', 'max_len', 'file']
+    with open(out_path, 'w', newline='') as fh:
+        w = csv.DictWriter(fh, fieldnames=fieldnames)
+        w.writeheader()
+        for r in rows:
+            w.writerow(r)
+
+
+# ── Sorting for readability ──────────────────────────────────────────────────
+def sort_rows(rows, step_order):
+    order_idx = {s: i for i, s in enumerate(step_order)}
+    type_order = {'single': 0, 'R1': 1, 'R2': 2, 'merged': 3, 'unmerged': 4,
+                  'merged+unmerged (combined)': 5}
+    return sorted(
+        rows,
+        key=lambda r: (
+            r['sample_id'],
+            order_idx.get(r['step'], 999),
+            type_order.get(r['read_type'], 9),
+        )
+    )
+
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+def parse_args():
+    p = argparse.ArgumentParser(
+        description="Combine per-step seqkit stats into one read-stats spreadsheet."
+    )
+    p.add_argument('-i', '--input_files', nargs='+', required=True,
+                   help="One or more `seqkit stats -T` TSV files, typically "
+                        "named <step>_seqkit.tsv")
+    p.add_argument('-o', '--output_file', required=True,
+                   help="Output CSV path (opens directly in Excel/LibreOffice/Sheets).")
+    p.add_argument('--step-order', nargs='+', default=None,
+                   help="Optional explicit ordering of step labels for output "
+                        "(e.g. --step-order Raw QC_trimmed Deduped NonHost).")
+    return p.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    all_rows = []
+    seen_steps = []
+    for path in args.input_files:
+        if not os.path.isfile(path):
+            print(f"[WARN] Skipping missing file: {path}", file=sys.stderr)
+            continue
+        step = step_label_from_filename(path)
+        if step not in seen_steps:
+            seen_steps.append(step)
+        all_rows.extend(parse_seqkit_table(path, step))
+
+    if not all_rows:
+        sys.exit("ERROR: No data parsed from any input file.")
+
+    all_rows = add_pair_rollups(all_rows)
+
+    step_order = args.step_order if args.step_order else seen_steps
+    all_rows = sort_rows(all_rows, step_order)
+
+    write_csv(all_rows, args.output_file)
+
+    n_samples = len({r['sample_id'] for r in all_rows})
+    print(f"[INFO] Wrote {len(all_rows)} rows for {n_samples} sample(s) "
+          f"across {len(step_order)} step(s) → {args.output_file}",
+          file=sys.stderr)
+
+
+if __name__ == '__main__':
+    main()

--- a/config/apptainer.config
+++ b/config/apptainer.config
@@ -5,4 +5,5 @@ process {
   withLabel: 'qiime2' { 
       container = 'enriquedoster/qiime2:latest'
   }
+  cpus = params.threads
 }

--- a/config/conda.config
+++ b/config/conda.config
@@ -5,4 +5,5 @@ process {
     withLabel: 'qiime2' { 
       conda = "$baseDir/envs/qiime2.yaml"
   }
+  cpus = params.threads
 }

--- a/config/conda_slurm.config
+++ b/config/conda_slurm.config
@@ -9,3 +9,71 @@ process {
   }
 }
 
+/* ------------------------------------------------------------------
+ *  Resource tiers (retry doubles time, x1.5 memory unless noted)
+ * ------------------------------------------------------------------ */
+process {
+    withLabel: nano {
+        cpus         = 20
+        errorStrategy = { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
+        maxRetries    = 1
+        memory        = { 512.MB  * (task.attempt > 1 ? 1.5 : 1) }
+        time          = {  5.m  * (task.attempt > 1 ? 1.5 : 1) }
+    }
+    withLabel: micro {
+        cpus         = 20
+        errorStrategy = { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
+        maxRetries    = 1
+        memory        = { 10.GB  * (task.attempt > 1 ? 1.5 : 1) }
+        time          = { 30.m  * (task.attempt > 1 ? 1.5 : 1) }
+    }
+    withLabel: micro_long {
+        cpus         = 20
+        errorStrategy = { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
+        maxRetries    = 1
+        memory        = { 20.GB  * (task.attempt > 1 ? 1.5 : 1) }
+        time          = { 1.5.h  * (task.attempt > 1 ? 1.5 : 1) }
+    }
+    withLabel: small {
+        cpus         = 20
+        errorStrategy = { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
+        maxRetries    = 1
+        memory        = { 20.GB  * (task.attempt > 1 ? 1.5 : 1) }
+        time          = { 2.h  * (task.attempt > 1 ? 1.5 : 1) }
+    }
+    withLabel: snp_ignore {
+        cpus         = 20
+        errorStrategy = 'ignore'
+        memory        = 20.GB 
+        time          = 2.h
+    }
+    withLabel: medium {
+        cpus         = 20
+        errorStrategy = { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
+        maxRetries    = 1
+        memory        = { 24.GB  * (task.attempt > 1 ? 1.5 : 1) }
+        time          = { 6.h  * (task.attempt > 1 ? 1.5 : 1) }
+    }
+    withLabel: large_short {
+        cpus         = 20
+        errorStrategy = { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
+        maxRetries    = 1
+        memory        = { 50.GB  * (task.attempt > 1 ? 1.5 : 1) }
+        time          = { 2.h  * (task.attempt > 1 ? 1.5 : 1) }
+    }
+    withLabel: large {
+        cpus         = 20
+        errorStrategy = { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
+        maxRetries    = 1
+        memory        = { 32.GB  * (task.attempt > 1 ? 1.5 : 1) }
+        time          = { 24.h  * (task.attempt > 1 ? 1.5 : 1) }
+    }
+    withLabel: xlarge {
+        cpus         = 20
+        errorStrategy = { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
+        maxRetries    = 1
+        memory        = { 256.GB  * (task.attempt > 1 ? 1.5 : 1) }
+        time          = { 1.5.h  * (task.attempt > 1 ? 1.5 : 1) }
+    }
+
+}

--- a/config/local.config
+++ b/config/local.config
@@ -4,5 +4,6 @@ process {
 
     errorStrategy = { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
     maxRetries    = 1
+    cpus = params.threads
 
 }

--- a/config/local_slurm.config
+++ b/config/local_slurm.config
@@ -37,7 +37,7 @@ process {
         cpus         = 20
         errorStrategy = { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
         maxRetries    = 1
-        memory        = { 10.GB  * (task.attempt > 1 ? 1.5 : 1) }
+        memory        = { 20.GB  * (task.attempt > 1 ? 1.5 : 1) }
         time          = { 1.5.h  * (task.attempt > 1 ? 1.5 : 1) }
     }
     withLabel: small {

--- a/config/local_slurm.config
+++ b/config/local_slurm.config
@@ -9,7 +9,6 @@ process {
 
 executor {
     name           = 'slurm'
-    submitTimeout  = '3 min'
     pollInterval   = '30 sec'
     perCpuMemAllocation = false
     queueSize      = 10

--- a/config/singularity.config
+++ b/config/singularity.config
@@ -5,4 +5,5 @@ process {
   withLabel: 'qiime2' { 
       container = 'enriquedoster/qiime2:latest'
   }
+  cpus = params.threads
 }

--- a/config/singularity_slurm.config
+++ b/config/singularity_slurm.config
@@ -8,3 +8,72 @@ process {
       container = 'enriquedoster/qiime2:latest'
   }
 }
+
+/* ------------------------------------------------------------------
+ *  Resource tiers (retry doubles time, x1.5 memory unless noted)
+ * ------------------------------------------------------------------ */
+process {
+    withLabel: nano {
+        cpus         = 20
+        errorStrategy = { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
+        maxRetries    = 1
+        memory        = { 512.MB  * (task.attempt > 1 ? 1.5 : 1) }
+        time          = {  5.m  * (task.attempt > 1 ? 1.5 : 1) }
+    }
+    withLabel: micro {
+        cpus         = 20
+        errorStrategy = { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
+        maxRetries    = 1
+        memory        = { 10.GB  * (task.attempt > 1 ? 1.5 : 1) }
+        time          = { 30.m  * (task.attempt > 1 ? 1.5 : 1) }
+    }
+    withLabel: micro_long {
+        cpus         = 20
+        errorStrategy = { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
+        maxRetries    = 1
+        memory        = { 20.GB  * (task.attempt > 1 ? 1.5 : 1) }
+        time          = { 1.5.h  * (task.attempt > 1 ? 1.5 : 1) }
+    }
+    withLabel: small {
+        cpus         = 20
+        errorStrategy = { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
+        maxRetries    = 1
+        memory        = { 20.GB  * (task.attempt > 1 ? 1.5 : 1) }
+        time          = { 2.h  * (task.attempt > 1 ? 1.5 : 1) }
+    }
+    withLabel: snp_ignore {
+        cpus         = 20
+        errorStrategy = 'ignore'
+        memory        = 20.GB 
+        time          = 2.h
+    }
+    withLabel: medium {
+        cpus         = 20
+        errorStrategy = { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
+        maxRetries    = 1
+        memory        = { 24.GB  * (task.attempt > 1 ? 1.5 : 1) }
+        time          = { 6.h  * (task.attempt > 1 ? 1.5 : 1) }
+    }
+    withLabel: large_short {
+        cpus         = 20
+        errorStrategy = { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
+        maxRetries    = 1
+        memory        = { 50.GB  * (task.attempt > 1 ? 1.5 : 1) }
+        time          = { 2.h  * (task.attempt > 1 ? 1.5 : 1) }
+    }
+    withLabel: large {
+        cpus         = 20
+        errorStrategy = { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
+        maxRetries    = 1
+        memory        = { 32.GB  * (task.attempt > 1 ? 1.5 : 1) }
+        time          = { 24.h  * (task.attempt > 1 ? 1.5 : 1) }
+    }
+    withLabel: xlarge {
+        cpus         = 20
+        errorStrategy = { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
+        maxRetries    = 1
+        memory        = { 256.GB  * (task.attempt > 1 ? 1.5 : 1) }
+        time          = { 1.5.h  * (task.attempt > 1 ? 1.5 : 1) }
+    }
+
+}

--- a/docs/Analysis_recommendations.md
+++ b/docs/Analysis_recommendations.md
@@ -45,7 +45,11 @@ Any characterization of individual genes should be performed with alternative bi
 
 ## Alignment Counting
 
-As of AMR++ v4, we only count 1 alignment hit per read. Previously we counted all alignments (including secondary and supplemental), but we now recommend only keeping primary alignments. You can still change this by modifying the `--samtools_flag` parameter.
+As of AMR++ v4, by default AMR++ counts at the FRAGMENT level: a paired-end read pair and a FLASH-merged read each count as one fragment, so the two library types are directly comparable. When the two mates of a pair land on different-but-near-identical gene accessions (common because MEGARes contains many minor variants of the same gene), group-aware resolution collapses that to a single count for the shared gene Group, crediting the accession whose mate had the higher match-quality (match_qcov_pct) — which stays meaningful even though such reads usually have MAPQ 0.
+
+Query coverage (fraction of a read that aligned) is computed with edge-awareness: a read that aligns cleanly but runs off the end of a short gene is not penalized for the overhang, and soft- vs hard-clipping no longer changes the number. A read clipped in the MIDDLE of a gene (where the gene continues but the read didn't align) is still correctly penalized. Gene fraction (breadth of the gene covered) is measured on the reference and is unaffected.
+
+To reproduce older behavior: count_mode=read_end (or alignment), group_aware=N, edge_aware_qcov=N.
 
 ## Rarefaction Analysis
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,11 @@
 Details on AMR++ updates
 ------------
 
+# 2026-07-26 Finalizing new alignment analyzer and updating to nextflow syntax v2
+- Update code to work with new nextflow syntax version
+- **Updated SNP confirmation tool (on a separate branch).** The SNP verifier now adjusts counts by the *proportion of reads that actually carry the confirmed SNP*: it computes (reads with the SNP / reads covering the SNP position) and multiplies by the gene's count, rather than substituting a raw resistant-read count. Genes that require SNP confirmation but have no entry in the SNP database are now set to zero (previously they passed through unconfirmed). The tool has also been updated to run cleanly under **Nextflow DSL2 syntax**.
+- **New coverage-threshold sweep workflow (`bam_coverage_sweep`).** Runs a set of pre-aligned BAMs across a grid of gene-fraction and query-coverage thresholds, then produces combined matrices and drop-off plots showing how the resistome (genes, classes, mechanisms, groups) shrinks as thresholds tighten — a way to choose sensible cutoffs and see each sample's sensitivity to them. See the [coverage sweep tutorial](docs/Coverage_sweep_tutorial.md).
+
 # 2026-07-08 Partial update
 - Fragment counting, group-aware fragment resolution, and edge-aware query-coverage are now ON
   BY DEFAULT (count_mode=fragment, group_aware=Y, edge_aware_qcov=Y):

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,20 @@
 Details on AMR++ updates
 ------------
 
+# 2026-07-08 Partial update
+- Fragment counting, group-aware fragment resolution, and edge-aware query-coverage are now ON
+  BY DEFAULT (count_mode=fragment, group_aware=Y, edge_aware_qcov=Y):
+  * fragment: merged and unmerged reads weighted identically (fixes Combined-BAM double-counting).
+  * group_aware: same-MEGARes-Group mate disagreements collapse to one hit (higher-match_qcov mate).
+  * edge_aware_qcov: qcov is soft/hard-clip invariant and forgives gene-edge overhang while still
+    penalizing genuinely partial (mid-gene) clips.
+- Unified alignment_analyzer.py and coverage_threshold_sweep.py: identical --group-aware flag
+  (old --group-aware-discordant kept as alias), identical match_qcov_pct tie-break, and both parse
+  MEGARes Group from the reference name (alignment_analyzer no longer needs --annotation for
+  group-aware).
+- All three can be disabled (count_mode=read_end|alignment, --no-group-aware, --no-edge-aware-qcov).
+
+
 ## 2026-01-19: AMR++ v3 update
 - Added functionality for single end reads and a pipeline to merge reads with FLASH and analyze both merged fragments and unmerged reads.
 - Resistome analysis: Changed default gene fraction threshold to "0" and changed extraction of alignments from the BAM file to only include primary alignments (one read = one alignment)

--- a/docs/Coverage_sweep_tutorial.md
+++ b/docs/Coverage_sweep_tutorial.md
@@ -1,0 +1,138 @@
+# Coverage Threshold Sweep: Step-by-Step Tutorial
+
+This tutorial covers the `bam_coverage_sweep` pipeline, which takes a set of pre-aligned BAM files and evaluates the resistome across a grid of **gene-fraction** and **query-coverage** thresholds. Instead of committing to a single cutoff, the sweep shows you how the number of detected genes (and classes, mechanisms, and groups) drops off as you tighten each threshold — so you can choose sensible cutoffs and see how sensitive each sample is to them. It produces combined result matrices and a set of drop-off plots.
+
+> **Before you start:** This pipeline runs on BAM files you have already produced with AMR++ (for example, the `*_alignment_sorted.bam` files under `Alignment/BAM_files/Standard/`). It also requires a few extra tools that are **not** bundled in the default AMR++ conda environment — see [Additional tools required](#additional-tools-required) below.
+
+## Table of Contents
+
+- [Additional tools required](#additional-tools-required)
+- [What the sweep does](#what-the-sweep-does)
+- [Running the sweep](#running-the-sweep)
+- [Choosing the threshold values](#choosing-the-threshold-values)
+- [Outputs](#outputs)
+- [Interpreting the plots](#interpreting-the-plots)
+
+---
+
+## Additional tools required
+
+The sweep uses a Python analysis step and an R plotting step whose dependencies are **not
+included in the AMR++ conda environment**, because adding them (especially the R plotting
+stack) would substantially increase an already-large environment. Install them separately
+before running the sweep.
+
+**Python (for `coverage_threshold_sweep.py` and `combine_sweep_results.py`):**
+- `pysam` — reading BAM alignments
+- `duckdb` — fast on-disk aggregation of the per-alignment table
+
+```bash
+# into your active AMR++ environment (or any python3 env you point the pipeline at)
+pip install pysam duckdb
+```
+
+**R (for `plot_sweep_dropoff.R`):**
+- `data.table`
+- `ggplot2`
+- `scales`
+
+```bash
+# from an R session, or Rscript -e '...'
+install.packages(c("data.table", "ggplot2", "scales"))
+```
+
+> If any of these are missing, the sweep step that needs them will fail. The Python step is
+> required to produce any output; the R step only affects the plots — if R isn't available you
+> will still get the combined CSV matrices, just not the figures.
+
+Make sure `Rscript` is on your `PATH` (the pipeline calls it via the `$RSCRIPT` environment
+variable; set `RSCRIPT` in your config/profile if your Rscript is in a non-standard location).
+
+---
+
+## What the sweep does
+
+For each BAM, the pipeline:
+1. Streams every primary alignment and records, per gene, its gene-fraction (breadth of the
+   reference covered) and query-coverage (fraction of the read aligned).
+2. Re-counts the resistome at every combination of the gene-fraction and query-coverage
+   thresholds in the sweep grid — using the same fragment-level, group-aware, edge-aware
+   counting as the main pipeline.
+3. Writes per-sample result CSVs.
+
+Then across all samples it:
+4. Combines the per-sample CSVs into single matrices (`combine_sweep_results.py`).
+5. Produces drop-off plots and summary tables (`plot_sweep_dropoff.R`).
+
+---
+
+## Running the sweep
+
+```bash
+nextflow run main_AMR++.nf \
+    -profile local \
+    --pipeline bam_coverage_sweep \
+    --bam_files "/path/to/Alignment/BAM_files/Standard/*_alignment_sorted.bam" \
+    --output MSS_sweep
+```
+
+- `--bam_files` is a glob matching the BAMs to sweep. Quote it so the shell doesn't expand it.
+- `--output` is where results are written.
+- On a cluster, swap `-profile local` for your SLURM profile (e.g. `-profile local_slurm`) —
+  see [Running with SLURM](Running_with_SLURM.md).
+
+Example with the SLURM profile:
+```bash
+nextflow run main_AMR++.nf \
+    --pipeline bam_coverage_sweep \
+    --bam_files "/scratch/$USER/MSS_output/Alignment/BAM_files/Standard/*" \
+    --output MSS_sweep \
+    -profile local_slurm
+```
+
+---
+
+## Choosing the threshold values
+
+The grids are defined as defaults in `bin/coverage_threshold_sweep.py` and can be overridden
+on the command line. Both gene-fraction and query-coverage are given as **proportions (0–1)**:
+
+- `--gene-fraction-sweep` default: `0, 0.1, 0.25, 0.5, 0.8`
+- `--query-coverage-sweep` default: `0, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95`
+- `--identity-sweep` default: `0` (off); note that identity, if used, is on a **0–100 percent**
+  scale, not a proportion.
+
+The default grid evaluates every combination (7 × 5 = 35 threshold pairs) in a single pass.
+
+> If you change the gene-fraction grid, update `GF_SWEEP` near the top of
+> `bin/plot_sweep_dropoff.R` to match, so the plots use the same values.
+
+---
+
+## Outputs
+
+Under `--output`, in `CoverageSweep/`:
+
+- `PerSample/` — one set of CSVs per BAM (`<prefix>_results.csv`, `_gene_detail.csv`,
+  `_length_quantiles.csv`).
+- `Combined/` — the merged matrices across all samples (`combined_results.csv`,
+  `combined_gene_detail.csv`, `combined_length_quantiles.csv`), each with a `sample_id` column.
+- `Summary/` (figures directory) — the drop-off plots (PNG) and summary tables (CSV).
+
+---
+
+## Interpreting the plots
+
+- **Drop-off curves** (`dropoff_<level>_count_vs_primary`, `_pct_vs_primary`) show, for each
+  annotation level (gene, class, mechanism, group), how the count falls as the primary
+  threshold tightens. The bold line is the mean across samples; each thin grey line is one
+  sample.
+- **Heatmaps** (`dropoff_<level>_heatmap`, `reads_retained_combined_heatmap_*`) show the joint
+  effect of both thresholds at once.
+- **Reads retained / lost** figures show what fraction of fragment-hits survive each threshold
+  relative to the no-filter baseline.
+
+Use these to pick thresholds where the resistome is stable (a plateau) rather than in a steep
+drop-off region, and to spot samples that are unusually sensitive to filtering. Once you've
+chosen cutoffs, apply them in the main pipeline via `--min_gene_fraction` and
+`--min_query_coverage` (same 0–1 proportion scale).

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -1,50 +1,241 @@
+# Getting Started with AMR++
 
-Getting started with AMR++
------------------
+This document will help you get AMR++ running on your system and understand the key concepts you'll encounter throughout your analysis. Before diving into a full tutorial, it's worth reading this page to understand how the pipeline is structured and how to get the most out of it.
 
-To get started, view the [Installation document](https://github.com/Microbial-Ecology-Group/AMRplusplus/blob/master/docs/installation.md) to determine the best way to install AMR++ to your computing cluster.
+## Table of Contents
 
-Next, we will run a small sample dataset that comes with the pipeline source code. As such, we will not be specifying any input paths as they have already been included. In this example, we'll assume that either all tools are installed and in your $PATH (or you installed the conda environment and activated the environment).
+- [Quick Start](#quick-start)
+- [Key Concepts](#key-concepts)
+  - [The Work Directory](#the-work-directory)
+  - [Running the Pipeline in Steps](#running-the-pipeline-in-steps)
+  - [Running the Demo First](#running-the-demo-first)
+  - [Conda vs Local Profiles](#conda-vs-local-profiles)
+  - [Running with SLURM](#running-with-slurm)
+- [Tutorials](#tutorials)
+- [Other Helpful Documents](#other-helpful-documents)
 
+---
+
+## Quick Start
+
+If you just want to get something running, here are the minimum steps:
 
 ```bash
-# If you followed the instructions on the installation document, you must now navigate to the AMR++ directory
+# 1. Clone the AMR++ repository
+git clone https://github.com/Microbial-Ecology-Group/AMRplusplus.git
 cd AMRplusplus
 
-# Run test of AMR++ by specifying the "-profile local".
-nextflow run main_AMR++.nf -profile local
+# 2. Create and activate the conda environment
+conda env create -f envs/AMR++_env.yaml
+conda activate AMR++_env
 
-# Explore the "test_results/" directory to view pipeline outputs
-ls test_results/
-
+# 3. Run the demo to confirm everything works and install SNP software
+nextflow run main_AMR++.nf -profile local --pipeline demo
 ```
 
+If the demo completes without errors, you're ready to analyze your data. Continue reading below to understand how to configure the pipeline for your needs.
 
-We can now change the "--pipeline" parameter to perform a different set of analyses. View the [configuration doc](#https://github.com/Microbial-Ecology-Group/AMRplusplus/blob/master/docs/configuration.md) for more details on pipeline options and modifying further parameters. 
+---
+
+## Key Concepts
+
+### The Work Directory
+
+Every time you run AMR++, Nextflow creates a `work/` directory in your current folder. This directory stores all intermediate files for every task — it's what allows Nextflow to `-resume` a failed run from where it left off without recomputing everything from scratch.
+
+**Important things to know about the work directory:**
+
+- It can grow very large, often tens to hundreds of gigabytes for a full dataset
+- It is safe to delete it once a pipeline step completes successfully, *as long as you don't need to `-resume` that run*
+- You can redirect it to a different location (e.g., a scratch drive) using the `-w` flag
 
 ```bash
-# Run another test, but now we add "--pipeline eval_qc" to only calculate QC stats.
-# We'll also change the "--output" flag to store the results in a new directory.
-nextflow run main_AMR++.nf -profile local --pipeline eval_qc --output test_QC_stats
-
-# View the results
-ls test_QC_stats/
-
-# Look at the multiqc_report.html and modify the params.config file to change trimming parameters.
-
-# Now, you can run just the QC trimming step with trimmomatic, by using the "--pipeline trim_qc" flag. Change output and work directory.
-nextflow run main_AMR++.nf -profile local --pipeline trim_qc --output test_QC_trimming -w work_trim
-
-# If the pipeline completes without issue, remember to erase your "work" directories to save storage space.
-
+# Redirect the work directory to a scratch drive with more space
+nextflow run main_AMR++.nf --pipeline trim_qc -w /scratch/$USER/nf_work
 ```
 
-
-Alternatively, you can run the entire pipeline as shown below.
+**Recommended practice when running in steps:** delete the work directory between steps to avoid filling your storage. For example:
 
 ```bash
+nextflow run main_AMR++.nf --pipeline trim_qc --output my_results
+# Confirm output looks correct, then:
+rm -rf work/
+```
 
-# You can use the "--pipeline standard_AMR" to run the standard AMR++ pipeline.
-nextflow run main_AMR++.nf -profile local --pipeline standard_AMR --output test_AMR++_output -w work_AMR++
+---
+
+### Running the Pipeline in Steps
+
+AMR++ supports running individual analysis steps independently using the `--pipeline` flag. This is recommended for large datasets because:
+
+1. **Storage management** — you can delete the `work/` directory between steps
+2. **Troubleshooting** — it's easier to identify and fix problems one step at a time
+3. **Flexibility** — you can swap in your own outputs at any stage (e.g., use pre-trimmed reads)
+4. **Compute efficiency** — on HPC systems, you only request resources for the specific step you need
+
+The typical order of steps for a paired-end analysis is:
 
 ```
+eval_qc → trim_qc → (dedup) → rm_host → resistome → (kraken)
+```
+
+For single-end data:
+```
+eval_qc → se_trim_qc → (se_dedup) → se_rm_host → se_resistome → (se_kraken)
+```
+
+For merged-read data:
+```
+eval_qc → trim_qc → (dedup) → merge_reads → merged_rm_host → merged_resistome → (merged_kraken)
+```
+
+See [Choosing the Right Pipeline](choosing_pipeline.md) for a full list of pipeline options and when to use each.
+
+---
+
+### Running the Demo First
+
+**Always run the demo before your first real analysis.** The demo serves two purposes:
+
+1. Confirms that your environment and all software dependencies are working correctly
+2. Downloads and installs the [SNP confirmation software](https://github.com/Isabella136/AmrPlusPlus_SNP) into `bin/AmrPlusPlus_SNP/`
+
+The SNP software is cloned from GitHub during the `build_dependencies` step. On HPC systems, compute nodes often do not have internet access, which means if you skip the demo and go straight to a full pipeline run on a compute node, the SNP software download will fail.
+
+```bash
+# Run the demo once from a login node (which has internet access)
+nextflow run main_AMR++.nf -profile local --pipeline demo
+```
+
+After the demo completes, the SNP software will be cached locally in `bin/` and subsequent pipeline runs on compute nodes will find it there without needing internet access.
+
+If you submit jobs via `sbatch` and skip the demo, you can alternatively add a WebProxy module to your sbatch script:
+
+```bash
+# Add to your sbatch script before the nextflow command
+module load WebProxy
+```
+
+---
+
+### Conda vs Local Profiles
+
+AMR++ uses the `-profile` flag to determine how it finds the required bioinformatic tools. The two most common options are `conda` and `local`, and understanding the difference matters for how you set up your jobs.
+
+**`-profile conda`**
+
+Nextflow manages the conda environment itself — it will create and activate it automatically. This is convenient but means Nextflow needs conda available at runtime.
+
+```bash
+nextflow run main_AMR++.nf -profile conda --pipeline demo
+```
+
+**`-profile local`**
+
+AMR++ assumes all required tools are already available in your current `$PATH`. This is the profile to use if you have already activated the conda environment yourself before running the pipeline.
+
+```bash
+# Activate the environment yourself first
+conda activate AMR++_env
+
+# Then run with -profile local — tools are already in your PATH
+nextflow run main_AMR++.nf -profile local --pipeline demo
+```
+
+**When does this matter?** On HPC systems with SLURM, you typically activate the conda environment in your `sbatch` script before calling nextflow, then use `-profile local_slurm`. This gives you more control over which environment is active and avoids Nextflow trying to manage conda in a job context. Example sbatch script:
+
+```bash
+#!/bin/bash
+#SBATCH --job-name=AMRplusplus
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=4G
+#SBATCH --time=48:00:00
+
+# Activate conda environment before calling nextflow
+module load Anaconda3/2024.02-1
+conda activate AMR++_env
+
+# Use local_slurm — tools are in PATH, SLURM handles job submission
+nextflow run main_AMR++.nf -profile local_slurm \
+    --pipeline standard_AMR \
+    --reads 'data/raw/*_R{1,2}.fastq.gz'
+```
+
+---
+
+### Running with SLURM
+
+If your institution uses SLURM as a job scheduler, using a `_slurm` profile is strongly recommended, especially for large datasets or when using a large Kraken database.
+
+**How it works:**
+
+When you use a `_slurm` profile (e.g., `local_slurm`, `conda_slurm`, `singularity_slurm`), you submit a lightweight "driver" job to SLURM — typically requesting just 1 CPU, 4 GB of memory, and a long walltime (24–48 hours). The Nextflow driver process stays running and automatically submits each individual pipeline step as its own separate SLURM job with the appropriate resource requests.
+
+This means:
+- High-memory steps like Kraken2 (which may need 256 GB) are submitted with that allocation automatically
+- Low-memory steps like indexing or result aggregation use minimal resources
+- You don't need to request the maximum memory for all steps upfront
+
+```bash
+#!/bin/bash
+#SBATCH --job-name=AMRplusplus_driver
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=4G
+#SBATCH --time=48:00:00
+
+module load Anaconda3/2024.02-1
+conda activate AMR++_env
+
+nextflow run main_AMR++.nf -profile local_slurm \
+    --pipeline standard_AMR \
+    --reads 'data/raw/*_R{1,2}.fastq.gz' \
+    --host /path/to/host_genome.fasta
+```
+
+**Controlling parallelism:** The `queueSize` parameter in the SLURM config (default: 10) controls how many jobs Nextflow submits to the scheduler simultaneously. You can raise this if your cluster allows more concurrent jobs.
+
+**Memory retry:** If a job fails with an out-of-memory error (exit codes 137–140), AMR++ automatically retries it with 1.5× the memory allocation — up to 3 attempts.
+
+For full details on resource tiers and how to customize them, see [Running with SLURM](Running_with_SLURM.md).
+
+---
+
+**Running without SLURM (local mode):**
+
+If you are on a single workstation or a login node with enough resources, you can run the entire pipeline locally:
+
+```bash
+nextflow run main_AMR++.nf -profile local \
+    --pipeline standard_AMR \
+    --reads 'data/raw/*_R{1,2}.fastq.gz'
+```
+
+In this mode, all processes run sequentially or with limited parallelism on the same machine. The `maxForks` setting in the config controls how many processes run simultaneously.
+
+---
+
+## Tutorials
+
+Step-by-step instructions for each read type:
+
+- **[Paired-end reads](Step_by_step_tutorial.md)** — standard Illumina R1 + R2 reads
+- **[Single-end reads](SingleEnd_read_tutorial.md)** — single-file FASTQ input
+- **[Merged reads](Merged_read_tutorial.md)** — reads merged with FLASH before analysis
+
+---
+
+## Other Helpful Documents
+
+| Document | Description |
+|----------|-------------|
+| [Installation](installation.md) | How to install AMR++ and its dependencies |
+| [Choosing a Pipeline](choosing_pipeline.md) | Full list of `--pipeline` options and when to use each |
+| [Configuration](configuration.md) | All parameters, how to modify `params.config`, profiles |
+| [Running with SLURM](Running_with_SLURM.md) | Resource labels, sbatch setup, memory tuning |
+| [Output](output.md) | Directory structure and description of all output files |
+| [Analysis Recommendations](Analysis_recommendations.md) | Tips on gene fraction thresholds, counting, rarefaction |
+| [Dependencies](dependencies.md) | Full list of software tools used |
+| [FAQs & Troubleshooting](FAQs.md) | Common errors and how to fix them |
+| [CHANGELOG](CHANGELOG.md) | Version history and updates |

--- a/docs/Merged_read_tutorial.md
+++ b/docs/Merged_read_tutorial.md
@@ -1,97 +1,318 @@
-# Overview of steps in AMR++ with merged reads
+# Merged-Read Analysis: Step-by-Step Tutorial
 
-# Confirm everything works
+This tutorial covers the AMR++ workflow for paired-end reads that are merged using FLASH before analysis. The merged-read approach is useful for amplicon or short-insert libraries where a significant proportion of R1 and R2 reads overlap and can be joined into a single longer fragment. Both the merged (overlapping) and unmerged (non-overlapping) reads are carried through the pipeline separately and combined at the results stage.
 
-You'll need to load the typical AMR++ environment, plus add "FLASH" and "SeqKit". Or you can simply re-install the AMR++ conda environment using the recipe as shown in the installation tutorial. 
+> **Before you start:** Make sure you have run the demo at least once from a login node (`nextflow run main_AMR++.nf -profile local --pipeline demo`). This installs the SNP confirmation software and verifies your environment. Your conda environment must also include FLASH and seqKit — if you installed the AMR++ environment from `envs/AMR++_env.yaml`, these are already included. See [Getting Started](GettingStarted.md) for details.
 
-You'll still need to run the "demo" as this downloads the github with the SNP confirmation software. If you forget to do this, make sure your sbatch script includes the module that allows internet connection (e.g. "module load WebProxy").
+## Table of Contents
 
-## Download a new AMR++ repository and switch to "dev" branch
+- [Setup](#setup)
+  - [Load the Conda Environment](#load-the-conda-environment)
+  - [How Merged-Read Analysis Works](#how-merged-read-analysis-works)
+- [Step 1: Quality Assessment (eval_qc)](#step-1-quality-assessment-eval_qc)
+- [Step 2: Quality Trimming (trim_qc)](#step-2-quality-trimming-trim_qc)
+- [Step 2.5 (Optional): Read Deduplication (dedup)](#step-25-optional-read-deduplication-dedup)
+- [Step 3: Merge Reads with FLASH (merge_reads)](#step-3-merge-reads-with-flash-merge_reads)
+- [Step 4: Host Read Removal (merged_rm_host)](#step-4-host-read-removal-merged_rm_host)
+- [Step 5: Resistome Analysis (merged_resistome)](#step-5-resistome-analysis-merged_resistome)
+- [Step 6 (Optional): Microbiome Analysis (merged_kraken)](#step-6-optional-microbiome-analysis-merged_kraken)
+- [Managing the Work Directory](#managing-the-work-directory)
 
+---
+
+## Setup
+
+### Load the Conda Environment
+
+```bash
+# Create the environment if you haven't already
+conda env create -f envs/AMR++_env.yaml
+
+# Activate before each session
+conda activate AMR++_env
 ```
-git clone https://github.com/Microbial-Ecology-Group/AMRplusplus
 
-cd AMRplusplus/
-
-git pull origin dev
+On HPC systems using modules:
+```bash
+module load Anaconda3/2024.02-1
+conda activate AMR++_env
 ```
 
-# Full pipeline
-
-You can run the full AMR++ pipeline (without kraken) by specifying the path to your `--reads` and using the `--pipeline merged_AMR` flag. This could work well if you re-direct the results or the work directory `-w /path/to/shared_drive`.
-
-## Step 1 : Run the "eval_qc" pipeline as normal with `--reads`
-
-Example command:
+Confirm that FLASH and seqKit are available:
+```bash
+flash --version
+seqkit version
+nextflow -version
 ```
-nextflow run main_AMR++.nf --pipeline eval_qc --output Merged_AMR++_analysis --reads "data/raw/*_R{1,2}.fastq.gz" -profile local
-``` 
 
-## Step 2: Run "trim_qc" pipeline as normal with `--reads`
-Modify trimming parameters as needed in the `params.txt` file. 
+### How Merged-Read Analysis Works
 
+After trimming, paired-end reads are passed to FLASH, which attempts to overlap R1 and R2 reads. This produces two output files per sample:
 
-Example command:
+| File suffix | Description |
+|-------------|-------------|
+| `.extendedFrags.fastq.gz` | Reads where R1 and R2 overlapped and were merged into a single longer fragment |
+| `.notCombined.fastq.gz` | Reads where R1 and R2 did not overlap and remain as separate SE-like reads |
+
+From Step 4 onward, both the merged and unmerged read fractions are processed in parallel and their results are combined. All downstream steps use `--merged_reads` instead of `--reads` to point to these two-file-per-sample outputs.
+
+> **Important:** When specifying `--merged_reads`, always use **single quotes** (`'`), not backticks or double quotes, around glob patterns that contain curly braces:
+> ```bash
+> --merged_reads 'path/to/files/*.{extendedFrags,notCombined}.fastq.gz'
+> ```
+
+---
+
+## Step 1: Quality Assessment (eval_qc)
+
+**What it does:** Runs FastQC and generates a MultiQC report on the raw paired-end reads before any processing.
+
+**Input:** Raw paired-end FASTQ files  
+**Output:** `Merged_AMR++_results/QC_analysis/`
+
+```bash
+nextflow run main_AMR++.nf \
+    -profile local \
+    --pipeline eval_qc \
+    --reads "data/raw/*_R{1,2}.fastq.gz" \
+    --output Merged_AMR++_results
 ```
-nextflow run main_AMR++.nf --pipeline trim_qc --output Merged_AMR++_analysis --reads "data/raw/*_R{1,2}.fastq.gz" -profile local
-``` 
 
-## Step 3: Run new "merge_reads" pipeline as normal with `--reads`
-
-### Parameters that have to change:
-* `--reads` ==> `--reads "Merged_AMR++_analysis/QC_trimming/Paired/*{1,2}P.fastq.gz"`
-* `--pipeline` ==> `--pipeline merge_reads`
-
-This will output two files per sample, the "extendedFrags" (merged) and "notCombined" (unmerged).
-Example command:
+```bash
+# Review the MultiQC report, then clean up
+ls Merged_AMR++_results/QC_analysis/
+rm -rf work/
 ```
-nextflow run main_AMR++.nf --pipeline merge_reads --output Merged_AMR++_analysis --reads "Merged_AMR++_analysis/QC_trimming/Paired/*{1,2}P.fastq.gz" -profile local
-``` 
 
+---
 
-## Step 4: Run "merged_rm_host" with a new flag, `--merged_reads`
+## Step 2: Quality Trimming (trim_qc)
 
-### Parameters to change
+**What it does:** Runs Trimmomatic in PE mode to remove adapters and low-quality bases before merging.
 
-Parameters that have to change:
-* `--pipeline` ==> `--pipeline merged_rm_host`
-* `--merged_reads`  ==> `--merged_reads 'Merged_AMR++_analysis/Flash_reads/*.{extendedFrags,notCombined}.fastq.gz'`
-    * Remember, it's very important to use the single quote (') and not the backtick or backquote (`) that's on the same key as the tilde. 
-* `host` ==> `--host "/path/to/your/host/chr21.fasta.gz"` 
-    * remember, you can change this in `params.config` file or add it to your nextflow command.
-    * On grace, bovine: `/scratch/group/big_scratch/SHARED_resources/host_genome/GCF_002263795.3_ARS-UCD2.0_genomic.fna`
+**Input:** Raw paired-end FASTQ files  
+**Output:**
+- `Merged_AMR++_results/QC_trimming/Paired/` — trimmed paired reads (`*.1P.fastq.gz`, `*.2P.fastq.gz`)
+- `Merged_AMR++_results/Results/Stats/trimmomatic.stats`
 
-Example command:
+**Default trimming parameters** (modify in `params.config` or on the command line):
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `--adapters` | nextera.fa | Adapter sequences to remove |
+| `--leading` | 3 | Minimum quality for leading bases |
+| `--trailing` | 3 | Minimum quality for trailing bases |
+| `--slidingwindow` | 4:15 | Window size : required average quality |
+| `--minlen` | 36 | Minimum read length after trimming |
+
+```bash
+nextflow run main_AMR++.nf \
+    -profile local \
+    --pipeline trim_qc \
+    --reads "data/raw/*_R{1,2}.fastq.gz" \
+    --output Merged_AMR++_results
 ```
-nextflow run main_AMR++.nf --pipeline merged_rm_host --output Merged_AMR++_analysis --merged_reads 'Merged_AMR++_analysis/Flash_reads/*.{extendedFrags,notCombined}.fastq.gz' -profile local
-``` 
 
-## Step 5: Run "merged_resistome" and point to non host reads with `--merged_reads`
-
-Parameters that have to change:
-* `--pipeline` ==> `--pipeline merged_resistome`
-* `--merged_reads`  ==> `--merged_reads 'Merged_AMR++_analysis/HostRemoval/NonHostFastq/*.{merged,unmerged}.non.host.fastq.gz'`
-
-SNP confirmation and alignment deduplication is performed by default.
-
-Example command:
+```bash
+ls Merged_AMR++_results/QC_trimming/Paired/
+rm -rf work/
 ```
-nextflow run main_AMR++.nf --pipeline merged_resistome --output Merged_AMR++_analysis --merged_reads 'Merged_AMR++_analysis/HostRemoval/NonHostFastq/*.{merged,unmerged}.non.host.fastq.gz' -profile local
-``` 
 
+---
 
-## Optional - Step 6: Run "merged_kraken" and point to non host reads with `--merged_reads`
+## Step 2.5 (Optional): Read Deduplication (dedup)
 
-Parameters that have to change:
-* `--pipeline` ==> `--pipeline merged_kraken`
-* `--kraken_db` ==> `--kraken_db /path/to/your/kraken_db`
+**What it does:** Uses seqkit to remove exact duplicate reads by sequence. Recommended for **target-enriched sequencing data**. This step is run on the trimmed paired-end reads *before* merging.
 
-If you don't specify a database with ```-kraken_db```, AMR++ will automatically download the "k2_minusb_20250714" database. 
+**Input:** QC-trimmed paired reads  
+**Output:** `Merged_AMR++_results/Deduped_reads/`
 
-Parameter still pointing to nonhost merged reads
-* `--merged_reads`  ==> `--merged_reads 'Merged_AMR++_analysis/HostRemoval/NonHostFastq/*.{merged,unmerged}.non.host.fastq.gz'`
-
-Example command:
+```bash
+nextflow run main_AMR++.nf \
+    -profile local \
+    --pipeline dedup \
+    --reads "Merged_AMR++_results/QC_trimming/Paired/*{1,2}P.fastq.gz" \
+    --output Merged_AMR++_results
 ```
-nextflow run main_AMR++.nf --pipeline merged_kraken --output Merged_AMR++_analysis --merged_reads 'Merged_AMR++_analysis/HostRemoval/NonHostFastq/*.{merged,unmerged}.non.host.fastq.gz' --kraken_db "/path/to/your/kraken_db" -profile local
-``` 
+
+```bash
+ls Merged_AMR++_results/Deduped_reads/
+rm -rf work/
+```
+
+---
+
+## Step 3: Merge Reads with FLASH (merge_reads)
+
+**What it does:** Attempts to overlap and merge R1 and R2 reads using FLASH. Produces two output files per sample: merged (extended fragments) and unmerged (not combined).
+
+**Input:** QC-trimmed paired reads (or deduped reads if you ran Step 2.5)  
+**Output:** `Merged_AMR++_results/Flash_reads/` — one `*.extendedFrags.fastq.gz` and one `*.notCombined.fastq.gz` per sample
+
+```bash
+# Using QC-trimmed reads
+nextflow run main_AMR++.nf \
+    -profile local \
+    --pipeline merge_reads \
+    --reads "Merged_AMR++_results/QC_trimming/Paired/*{1,2}P.fastq.gz" \
+    --output Merged_AMR++_results
+
+# OR using deduped reads (if you ran Step 2.5)
+nextflow run main_AMR++.nf \
+    -profile local \
+    --pipeline merge_reads \
+    --reads "Merged_AMR++_results/Deduped_reads/*R{1,2}.dedup.fastq.gz" \
+    --output Merged_AMR++_results
+```
+
+**Inspect results:**
+```bash
+ls Merged_AMR++_results/Flash_reads/
+# You should see pairs of files per sample:
+#   sample.extendedFrags.fastq.gz
+#   sample.notCombined.fastq.gz
+```
+
+```bash
+rm -rf work/
+```
+
+---
+
+## Step 4: Host Read Removal (merged_rm_host)
+
+**What it does:** Aligns both the merged and unmerged read fractions against the host genome. Non-host reads are extracted from each fraction separately.
+
+**Input:** FLASH output files from Step 3 (use `--merged_reads`, not `--reads`)  
+**Output:** `Merged_AMR++_results/HostRemoval/NonHostFastq/` — one `*.merged.non.host.fastq.gz` and one `*.unmerged.non.host.fastq.gz` per sample
+
+**Parameters to set:**
+
+| Parameter | Description |
+|-----------|-------------|
+| `--host` | Path to your host genome FASTA. For bovine on Grace HPRC: `/scratch/group/big_scratch/SHARED_resources/host_genome/GCF_002263795.3_ARS-UCD2.0_genomic.fna` |
+| `--merged_reads` | Glob pointing to FLASH output files — **use single quotes** |
+
+```bash
+nextflow run main_AMR++.nf \
+    -profile local \
+    --pipeline merged_rm_host \
+    --merged_reads 'Merged_AMR++_results/Flash_reads/*.{extendedFrags,notCombined}.fastq.gz' \
+    --host /path/to/host_genome.fasta \
+    --output Merged_AMR++_results
+```
+
+**Inspect results:**
+```bash
+ls Merged_AMR++_results/HostRemoval/NonHostFastq/
+# Expected output per sample:
+#   sample.merged.non.host.fastq.gz
+#   sample.unmerged.non.host.fastq.gz
+```
+
+```bash
+rm -rf work/
+```
+
+---
+
+## Step 5: Resistome Analysis (merged_resistome)
+
+**What it does:** Aligns both the merged and unmerged non-host fractions to MEGARes and generates combined count matrices with optional SNP confirmation.
+
+**Input:** Non-host FASTQ files from Step 4 (use `--merged_reads`, not `--reads`)  
+**Output:**
+- `Merged_AMR++_results/Results/AMR_analytic_matrix.csv`
+- `Merged_AMR++_results/Results/SNPconfirmed_AMR_analytic_matrix.csv` (if `--snp Y`)
+- `Merged_AMR++_results/Results/dedup_AMR_analytic_matrix.csv` (if `--deduped Y`)
+
+**Key parameters:**
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `--threshold` | 0 | Gene fraction threshold. Keep at 0 and aggregate to Group level |
+| `--snp` | N | Set to `Y` to enable SNP confirmation |
+| `--deduped` | N | Set to `Y` to output deduplicated alignment counts (different than read deduplication) |
+
+```bash
+nextflow run main_AMR++.nf \
+    -profile local \
+    --pipeline merged_resistome \
+    --merged_reads 'Merged_AMR++_results/HostRemoval/NonHostFastq/*.{merged,unmerged}.non.host.fastq.gz' \
+    --snp Y \
+    --deduped Y \
+    --output Merged_AMR++_results
+```
+
+**Inspect results:**
+```bash
+ls Merged_AMR++_results/Results/
+head Merged_AMR++_results/Results/AMR_analytic_matrix.csv
+wc -l Merged_AMR++_results/Results/AM*
+```
+
+```bash
+rm -rf work/
+```
+
+---
+
+## Step 6 (Optional): Microbiome Analysis (merged_kraken)
+
+**What it does:** Classifies both merged and unmerged non-host reads using Kraken2. Merged reads are classified normally; unmerged reads use the `--interleaved` flag so each pair counts as a single classification. Results are combined into a single matrix.
+
+**Input:** Non-host FASTQ files from Step 4 (use `--merged_reads`)  
+**Output:**
+- `Merged_AMR++_results/MicrobiomeAnalysis/Kraken/` — per-sample reports for merged and unmerged
+- `Merged_AMR++_results/Results/kraken_analytic_matrix.conf_${kraken_confidence}.csv`
+
+> **Memory note:** Kraken2 requires enough RAM to load the full database. For large databases (e.g., core_nt), use a SLURM `xlarge` allocation. See [Running with SLURM](Running_with_SLURM.md).
+
+```bash
+nextflow run main_AMR++.nf \
+    -profile local \
+    --pipeline merged_kraken \
+    --merged_reads 'Merged_AMR++_results/HostRemoval/NonHostFastq/*.{merged,unmerged}.non.host.fastq.gz' \
+    --kraken_db /path/to/kraken_db \
+    --output Merged_AMR++_results
+```
+
+**Inspect results:**
+```bash
+head Merged_AMR++_results/Results/kraken_analytic_matrix.conf_0.0.csv
+head Merged_AMR++_results/Results/unclassifieds_kraken_analytic_matrix.conf_0.0.csv
+```
+
+```bash
+rm -rf work/
+```
+
+---
+
+## Managing the Work Directory
+
+The `work/` directory enables `-resume` but can grow to many gigabytes between steps. Delete it after each step completes successfully.
+
+```bash
+# Check size
+du -sh work/
+
+# Delete after confirming output is correct
+rm -rf work/
+
+# Redirect to a scratch drive
+nextflow run main_AMR++.nf -profile local --pipeline merge_reads \
+    --reads "Merged_AMR++_results/QC_trimming/Paired/*{1,2}P.fastq.gz" \
+    -w /scratch/$USER/nf_work_merge
+```
+
+To resume a failed run (work directory must still exist):
+```bash
+nextflow run main_AMR++.nf \
+    -profile local \
+    --pipeline merged_rm_host \
+    --merged_reads 'Merged_AMR++_results/Flash_reads/*.{extendedFrags,notCombined}.fastq.gz' \
+    --host /path/to/host_genome.fasta \
+    --output Merged_AMR++_results \
+    -resume
+```

--- a/docs/Merged_read_tutorial.md
+++ b/docs/Merged_read_tutorial.md
@@ -2,7 +2,7 @@
 
 This tutorial covers the AMR++ workflow for paired-end reads that are merged using FLASH before analysis. The merged-read approach is useful for amplicon or short-insert libraries where a significant proportion of R1 and R2 reads overlap and can be joined into a single longer fragment. Both the merged (overlapping) and unmerged (non-overlapping) reads are carried through the pipeline separately and combined at the results stage.
 
-> **Before you start:** Make sure you have run the demo at least once from a login node (`nextflow run main_AMR++.nf -profile local --pipeline demo`). This installs the SNP confirmation software and verifies your environment. Your conda environment must also include FLASH and seqKit — if you installed the AMR++ environment from `envs/AMR++_env.yaml`, these are already included. See [Getting Started](GettingStarted.md) for details.
+> **Before you start:** Make sure you have run the demo at least once from a login node (`nextflow run main_AMR++.nf -profile local --pipeline demo`). This installs the SNP confirmation software and verifies your environment. Your conda environment must also include FLASH and bbmap's clumpify — if you installed the AMR++ environment from `envs/AMR++_env.yaml`, these are already included. See [Getting Started](GettingStarted.md) for details.
 
 ## Table of Contents
 
@@ -38,10 +38,10 @@ module load Anaconda3/2024.02-1
 conda activate AMR++_env
 ```
 
-Confirm that FLASH and seqKit are available:
+Confirm that FLASH and bbmap's clumpify are available:
 ```bash
 flash --version
-seqkit version
+bbmap's clumpify version
 nextflow -version
 ```
 
@@ -122,7 +122,7 @@ rm -rf work/
 
 ## Step 2.5 (Optional): Read Deduplication (dedup)
 
-**What it does:** Uses seqkit to remove exact duplicate reads by sequence. Recommended for **target-enriched sequencing data**. This step is run on the trimmed paired-end reads *before* merging.
+**What it does:** Uses bbmap's clumpify to remove exact duplicate reads by sequence. Recommended for **target-enriched sequencing data**. This step is run on the trimmed paired-end reads *before* merging.
 
 **Input:** QC-trimmed paired reads  
 **Output:** `Merged_AMR++_results/Deduped_reads/`

--- a/docs/Merged_read_tutorial.md
+++ b/docs/Merged_read_tutorial.md
@@ -255,6 +255,12 @@ wc -l Merged_AMR++_results/Results/AM*
 rm -rf work/
 ```
 
+> **Optional — tune your thresholds:** The resistome step above produces per-sample BAM files
+> (under `Alignment/BAM_files/`). If you'd like to see how your resistome results change as you
+> tighten gene-fraction and query-coverage cutoffs, and pick sensible thresholds, run the
+> [coverage threshold sweep](Coverage_sweep_tutorial.md) on those BAMs.
+
+
 ---
 
 ## Step 6 (Optional): Microbiome Analysis (merged_kraken)

--- a/docs/SingleEnd_read_tutorial.md
+++ b/docs/SingleEnd_read_tutorial.md
@@ -1,84 +1,303 @@
-# Overview of steps in AMR++ with merged reads
+# Single-End Analysis: Step-by-Step Tutorial
 
-# Confirm everything works
+This tutorial walks through a complete AMR++ analysis for single-end sequencing data, running each step independently. The single-end pipeline mirrors the paired-end workflow but uses SE-specific subworkflows prefixed with `se_`.
 
-You'll need to load the typical AMR++ environment, plus add "FLASH" and "SeqKit". Or you can simply re-install the AMR++ conda environment using the recipe as shown in the installation tutorial. 
+> **Before you start:** Make sure you have run the demo at least once from a login node (`nextflow run main_AMR++.nf -profile local --pipeline demo`). This installs the SNP confirmation software and verifies your environment. See [Getting Started](GettingStarted.md) for details.
 
-You'll still need to run the "demo" as this downloads the github with the SNP confirmation software. If you forget to do this, make sure your sbatch script includes the module that allows internet connection (e.g. "module load WebProxy").
+## Table of Contents
 
-## Download a new AMR++ repository and switch to "dev" branch
+- [Setup](#setup)
+  - [Load the Conda Environment](#load-the-conda-environment)
+  - [Single-End vs Paired-End Input](#single-end-vs-paired-end-input)
+- [Step 1: Quality Assessment (eval_qc)](#step-1-quality-assessment-eval_qc)
+- [Step 2: Quality Trimming (se_trim_qc)](#step-2-quality-trimming-se_trim_qc)
+- [Step 2.5 (Optional): Read Deduplication (se_dedup)](#step-25-optional-read-deduplication-se_dedup)
+- [Step 3: Host Read Removal (se_rm_host)](#step-3-host-read-removal-se_rm_host)
+- [Step 4: Resistome Analysis (se_resistome)](#step-4-resistome-analysis-se_resistome)
+- [Step 5 (Optional): Microbiome Analysis (se_kraken)](#step-5-optional-microbiome-analysis-se_kraken)
+- [Managing the Work Directory](#managing-the-work-directory)
 
+---
+
+## Setup
+
+### Load the Conda Environment
+
+```bash
+# If you haven't installed the conda environment yet
+conda env create -f envs/AMR++_env.yaml
+
+# Activate before each session
+conda activate AMR++_env
 ```
-git clone https://github.com/Microbial-Ecology-Group/AMRplusplus
 
-cd AMRplusplus/
-
-git pull origin dev
+On HPC systems using modules:
+```bash
+module load Anaconda3/2024.02-1
+conda activate AMR++_env
 ```
 
-# Full pipeline
-
-You can run the full AMR++ pipeline (without kraken) by specifying the path to your `--reads` and using the `--pipeline se_AMR` flag. This could work well if you re-direct the results or the work directory `-w /path/to/shared_drive`.
-
-## Step 1 : Run the "eval_qc" pipeline as normal with `--reads`
-
-Example command:
+Confirm tools are available:
+```bash
+nextflow -version
+bwa 2>&1 | head -3
+samtools --version | head -1
 ```
-nextflow run main_AMR++.nf --pipeline eval_qc --output SE_AMR++_analysis --reads "data/raw/*.fastq.gz" -profile local
-``` 
 
-## Step 2: Run "se_trim_qc" pipeline with `--reads`
-Modify trimming parameters as needed in the `params.txt` file. 
-Notice the `--reads` flag does not require a regular expression pattern to match paired reads, we can just use the asterisk "*" and file extension name to point to all samples. 
+### Single-End vs Paired-End Input
 
-Example command:
+The key difference in running the single-end pipeline is how you specify `--reads`. For single-end data, each sample is a single FASTQ file, so the glob pattern does not use the `{1,2}` syntax:
+
+```bash
+# Paired-end (matches R1 and R2 pairs)
+--reads "data/raw/*_R{1,2}.fastq.gz"
+
+# Single-end (matches individual files)
+--reads "data/raw/*.fastq.gz"
 ```
-nextflow run main_AMR++.nf --pipeline se_trim_qc --output SE_AMR++_analysis --reads "data/raw/*.fastq.gz" -profile local
-``` 
 
+AMR++ automatically detects the read type from the glob pattern and routes to the correct pipeline.
 
+---
 
-## Step 3: Run "se_rm_host" with `--reads`
+## Step 1: Quality Assessment (eval_qc)
 
-### Parameters to change
+**What it does:** Runs FastQC on all input reads and generates a MultiQC summary report.
 
-Parameters that have to change:
-* `--pipeline` ==> `--pipeline rm_host`
-* `--reads`  ==> `--reads "SE_AMR++_analysis/HostRemoval/NonHostFastq/*.fastq.gz"`
-* `host` ==> `--host "/path/to/your/host/chr21.fasta.gz"` 
-    * remember, you can change this in `params.config` file or add it to your nextflow command.
-    * On grace, bovine: `/scratch/group/big_scratch/SHARED_resources/host_genome/GCF_002263795.3_ARS-UCD2.0_genomic.fna`
+**Input:** Raw single-end FASTQ files  
+**Output:** `SE_AMR++_results/QC_analysis/FastQC/` and `SE_AMR++_results/QC_analysis/MultiQC_stats/multiqc_report.html`
 
-Example command:
+> Note: `eval_qc` works the same for both single-end and paired-end data — you do not need a separate `se_eval_qc` pipeline for this step.
+
+```bash
+nextflow run main_AMR++.nf \
+    -profile local \
+    --pipeline eval_qc \
+    --reads "data/raw/*.fastq.gz" \
+    --output SE_AMR++_results
 ```
-nextflow run main_AMR++.nf --pipeline se_rm_host --output SE_AMR++_analysis --reads "SE_AMR++_analysis/HostRemoval/NonHostFastq/*.fastq.gz" -profile local
-``` 
 
-## Step 4: Run "se_resistome" and point to non host reads with `--reads`
-
-Parameters that have to change:
-* `--pipeline` ==> `--pipeline se_resistome`
-* `--reads`  ==> `--reads "SE_AMR++_analysis/HostRemoval/NonHostFastq/*.fastq.gz"`
-
-SNP confirmation and alignment deduplication is performed by default.
-
-Example command:
+**Explore results:**
+```bash
+ls SE_AMR++_results/QC_analysis/FastQC/
+# Download and open multiqc_report.html in a browser
 ```
-nextflow run main_AMR++.nf --pipeline se_resistome --output SE_AMR++_analysis --reads "SE_AMR++_analysis/HostRemoval/NonHostFastq/*.fastq.gz" -profile local
-``` 
 
-
-## Optional - Step 5: Run "se_kraken" and point to non host reads with `--reads`
-
-Parameters that have to change:
-* `--pipeline` ==> `--pipeline se_kraken`
-* `--kraken_db` ==> `--kraken_db /path/to/your/kraken_db`
-
-
-Parameter still pointing to nonhost merged reads
-* `--reads`  ==> `--reads 'SE_AMR++_analysis/HostRemoval/NonHostFastq/*.{merged,unmerged}.non.host.fastq.gz'`
-
-Example command:
+```bash
+rm -rf work/
 ```
-nextflow run main_AMR++.nf --pipeline se_kraken --output SE_AMR++_analysis --reads "SE_AMR++_analysis/HostRemoval/NonHostFastq/*.fastq.gz" --kraken_db "/path/to/your/kraken_db" -profile local
-``` 
+
+---
+
+## Step 2: Quality Trimming (se_trim_qc)
+
+**What it does:** Runs Trimmomatic in SE mode to remove adapters and low-quality bases.
+
+**Input:** Raw single-end FASTQ files  
+**Output:**
+- `SE_AMR++_results/QC_trimming/Single/` — trimmed reads (`*.trimmed.fastq.gz`)
+- `SE_AMR++_results/Results/Stats/trimmomatic.stats` — per-sample read counts
+
+**Default trimming parameters** (modify in `params.config` or on the command line):
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `--adapters` | nextera.fa | Adapter sequences to remove |
+| `--leading` | 3 | Minimum quality for leading bases |
+| `--trailing` | 3 | Minimum quality for trailing bases |
+| `--slidingwindow` | 4:15 | Window size : required average quality |
+| `--minlen` | 36 | Minimum read length after trimming |
+
+```bash
+nextflow run main_AMR++.nf \
+    -profile local \
+    --pipeline se_trim_qc \
+    --reads "data/raw/*.fastq.gz" \
+    --output SE_AMR++_results
+```
+
+**Inspect results:**
+```bash
+ls SE_AMR++_results/QC_trimming/Single/
+cat SE_AMR++_results/Results/Stats/trimmomatic.stats
+```
+
+```bash
+rm -rf work/
+```
+
+---
+
+## Step 2.5 (Optional): Read Deduplication (se_dedup)
+
+**What it does:** Uses seqkit to remove exact duplicate reads by sequence. Recommended for **target-enriched sequencing data** (probe-based capture) where PCR duplicates are common.
+
+**Input:** QC-trimmed single-end reads  
+**Output:** `SE_AMR++_results/Deduped_reads/` — deduplicated reads (`*.dedup.fastq.gz`)
+
+```bash
+nextflow run main_AMR++.nf \
+    -profile local \
+    --pipeline se_dedup \
+    --reads "SE_AMR++_results/QC_trimming/Single/*.trimmed.fastq.gz" \
+    --output SE_AMR++_results
+```
+
+**Inspect results:**
+```bash
+ls SE_AMR++_results/Deduped_reads/
+```
+
+```bash
+rm -rf work/
+```
+
+---
+
+## Step 3: Host Read Removal (se_rm_host)
+
+**What it does:** Aligns single-end reads against the host genome using BWA. Unmapped reads are extracted and saved as non-host FASTQ files for downstream analysis.
+
+**Input:** Trimmed (or deduped) single-end reads  
+**Output:**
+- `SE_AMR++_results/HostRemoval/NonHostFastq/` — non-host reads (`*.non.host.fastq.gz`)
+- `SE_AMR++_results/Results/Stats/host.removal.stats` — read counts
+
+**Parameters to set:**
+
+| Parameter | Description |
+|-----------|-------------|
+| `--host` | Path to your host genome FASTA. For bovine on Grace HPRC: `/scratch/group/big_scratch/SHARED_resources/host_genome/GCF_002263795.3_ARS-UCD2.0_genomic.fna` |
+| `--reads` | Point to trimmed reads (or deduped reads if you ran Step 2.5) |
+
+```bash
+# Using QC-trimmed reads
+nextflow run main_AMR++.nf \
+    -profile local \
+    --pipeline se_rm_host \
+    --reads "SE_AMR++_results/QC_trimming/Single/*.trimmed.fastq.gz" \
+    --host /path/to/host_genome.fasta \
+    --output SE_AMR++_results
+
+# OR using deduped reads (if you ran Step 2.5)
+nextflow run main_AMR++.nf \
+    -profile local \
+    --pipeline se_rm_host \
+    --reads "SE_AMR++_results/Deduped_reads/*.dedup.fastq.gz" \
+    --host /path/to/host_genome.fasta \
+    --output SE_AMR++_results
+```
+
+**Inspect results:**
+```bash
+ls SE_AMR++_results/HostRemoval/NonHostFastq/
+cat SE_AMR++_results/Results/Stats/host.removal.stats
+```
+
+```bash
+rm -rf work/
+```
+
+---
+
+## Step 4: Resistome Analysis (se_resistome)
+
+**What it does:** Aligns non-host reads to the MEGARes database and generates count matrices at all annotation levels, with optional SNP confirmation and deduplicated counts.
+
+**Input:** Non-host FASTQ files from Step 3  
+**Output:**
+- `SE_AMR++_results/Results/AMR_analytic_matrix.csv`
+- `SE_AMR++_results/Results/SNPconfirmed_AMR_analytic_matrix.csv` (if `--snp Y`)
+- `SE_AMR++_results/Results/dedup_AMR_analytic_matrix.csv` (if `--deduped Y`)
+- `SE_AMR++_results/ResistomeAnalysis/ResistomeCounts/` — per-sample count files
+
+**Key parameters:**
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `--threshold` | 0 | Gene fraction threshold. Keep at 0 and aggregate to Group level for analysis |
+| `--snp` | N | Set to `Y` to enable SNP confirmation |
+| `--deduped` | N | Set to `Y` to output deduplicated alignment counts |
+
+```bash
+nextflow run main_AMR++.nf \
+    -profile local \
+    --pipeline se_resistome \
+    --reads "SE_AMR++_results/HostRemoval/NonHostFastq/*.non.host.fastq.gz" \
+    --snp Y \
+    --deduped Y \
+    --output SE_AMR++_results
+```
+
+**Inspect results:**
+```bash
+ls SE_AMR++_results/Results/
+head SE_AMR++_results/Results/AMR_analytic_matrix.csv
+wc -l SE_AMR++_results/Results/AM*
+```
+
+```bash
+rm -rf work/
+```
+
+---
+
+## Step 5 (Optional): Microbiome Analysis (se_kraken)
+
+**What it does:** Classifies non-host reads taxonomically using Kraken2 and generates a wide-format count matrix.
+
+**Input:** Non-host FASTQ files from Step 3  
+**Output:**
+- `SE_AMR++_results/MicrobiomeAnalysis/Kraken/` — per-sample reports
+- `SE_AMR++_results/Results/kraken_analytic_matrix.conf_${kraken_confidence}.csv`
+
+> **Memory note:** Kraken2 loads the entire database into RAM. For large databases, make sure your job has sufficient memory. See [Running with SLURM](Running_with_SLURM.md) for memory allocation details.
+
+```bash
+nextflow run main_AMR++.nf \
+    -profile local \
+    --pipeline se_kraken \
+    --reads "SE_AMR++_results/HostRemoval/NonHostFastq/*.non.host.fastq.gz" \
+    --kraken_db /path/to/kraken_db \
+    --output SE_AMR++_results
+```
+
+**Inspect results:**
+```bash
+head SE_AMR++_results/Results/kraken_analytic_matrix.conf_0.0.csv
+head SE_AMR++_results/Results/unclassifieds_kraken_analytic_matrix.conf_0.0.csv
+```
+
+```bash
+rm -rf work/
+```
+
+---
+
+## Managing the Work Directory
+
+The `work/` directory enables `-resume` but grows large quickly. Delete it after each step completes successfully.
+
+```bash
+# Check size
+du -sh work/
+
+# Delete after confirming output looks correct
+rm -rf work/
+
+# Redirect to a scratch drive with more space
+nextflow run main_AMR++.nf -profile local --pipeline se_rm_host \
+    --reads "SE_AMR++_results/QC_trimming/Single/*.trimmed.fastq.gz" \
+    --host /path/to/host_genome.fasta \
+    -w /scratch/$USER/nf_work_host_removal
+```
+
+To resume a failed run (work directory must still exist):
+```bash
+nextflow run main_AMR++.nf \
+    -profile local \
+    --pipeline se_resistome \
+    --reads "SE_AMR++_results/HostRemoval/NonHostFastq/*.non.host.fastq.gz" \
+    --output SE_AMR++_results \
+    -resume
+```

--- a/docs/SingleEnd_read_tutorial.md
+++ b/docs/SingleEnd_read_tutorial.md
@@ -240,6 +240,13 @@ wc -l SE_AMR++_results/Results/AM*
 rm -rf work/
 ```
 
+> **Optional — tune your thresholds:** The resistome step above produces per-sample BAM files
+> (under `Alignment/BAM_files/`). If you'd like to see how your resistome results change as you
+> tighten gene-fraction and query-coverage cutoffs, and pick sensible thresholds, run the
+> [coverage threshold sweep](Coverage_sweep_tutorial.md) on those BAMs.
+
+
+
 ---
 
 ## Step 5 (Optional): Microbiome Analysis (se_kraken)

--- a/docs/SingleEnd_read_tutorial.md
+++ b/docs/SingleEnd_read_tutorial.md
@@ -130,7 +130,7 @@ rm -rf work/
 
 ## Step 2.5 (Optional): Read Deduplication (se_dedup)
 
-**What it does:** Uses seqkit to remove exact duplicate reads by sequence. Recommended for **target-enriched sequencing data** (probe-based capture) where PCR duplicates are common.
+**What it does:** Uses bbmap's clumpify to remove exact duplicate reads by sequence. Recommended for **target-enriched sequencing data** (probe-based capture) where PCR duplicates are common.
 
 **Input:** QC-trimmed single-end reads  
 **Output:** `SE_AMR++_results/Deduped_reads/` — deduplicated reads (`*.dedup.fastq.gz`)

--- a/docs/Step_by_step_tutorial.md
+++ b/docs/Step_by_step_tutorial.md
@@ -1,362 +1,348 @@
-# Tutorial to run AMR++ in steps
+# Paired-End Analysis: Step-by-Step Tutorial
 
-The tutorial below takes you through the process of installing AMR++ and analyzing your data in steps, instead of running the entire pipeline. This can be useful if you wish to only perform certain components or your dataset size is extremely large and you need to reduce the size of the temporary files that are created in the working directory. 
+This tutorial walks through a complete paired-end AMR++ analysis, running each step independently. This approach is recommended for large datasets because it lets you delete the `work/` directory between steps to manage storage, and makes it easier to troubleshoot individual steps.
 
-It's important to note that nextflow populates the "work" directory with temporary files that allow for nextflow to "-resume" a failed run and pick up where it left off. Therefore, running AMR++ in steps allows for the removal of the "work" directory between every run. 
+> **Before you start:** Make sure you have run the demo at least once from a login node (`nextflow run main_AMR++.nf -profile local --pipeline demo`). This installs the SNP confirmation software and verifies your environment. See [Getting Started](GettingStarted.md) for details.
 
-# Table of Contents
-- [Tutorial to run AMR++ in steps](#tutorial-to-run-amr-in-steps)
-- [Table of Contents](#table-of-contents)
-- [Load conda environment](#load-conda-environment)
-    - [Check conda installation](#check-conda-installation)
-      - [Using server modules](#using-server-modules)
-      - [Using miniconda](#using-miniconda)
-    - [Install AMR++ environment](#install-amr-environment)
-- [Run first Demo](#run-first-demo)
-  - [How did AMR++ know what parameters to run:](#how-did-amr-know-what-parameters-to-run)
-- [AMR++ components](#amr-components)
-- [Run the eval\_qc pipeline](#run-the-eval_qc-pipeline)
-  - [Run first pipeline, eval\_qc](#run-first-pipeline-eval_qc)
-  - [Explore QC results](#explore-qc-results)
-- [Run trim\_qc pipeline](#run-trim_qc-pipeline)
-  - [trim\_qc command](#trim_qc-command)
-    - [Download trimmomatic.stats file and open on excel](#download-trimmomaticstats-file-and-open-on-excel)
-    - [Now, we'll talk about removing contaminant host DNA](#now-well-talk-about-removing-contaminant-host-dna)
-- [Run host removal pipeline](#run-host-removal-pipeline)
-  - [rm\_host command](#rm_host-command)
-    - [Evaluate rm\_host results](#evaluate-rm_host-results)
-- [Run resistome pipeline](#run-resistome-pipeline)
-  - [resistome commmand](#resistome-commmand)
-  - [Evalute resistome results](#evalute-resistome-results)
-- [Run kraken pipeline](#run-kraken-pipeline)
-  - [kraken command](#kraken-command)
-  - [Inspect kraken results](#inspect-kraken-results)
-- [Effect of changing important parameters](#effect-of-changing-important-parameters)
-  - [Resistome](#resistome)
-  - [Kraken](#kraken)
+## Table of Contents
 
+- [Setup](#setup)
+  - [Load the Conda Environment](#load-the-conda-environment)
+  - [Confirm Tools Are Available](#confirm-tools-are-available)
+- [Step 1: Quality Assessment (eval_qc)](#step-1-quality-assessment-eval_qc)
+- [Step 2: Quality Trimming (trim_qc)](#step-2-quality-trimming-trim_qc)
+- [Step 2.5 (Optional): Read Deduplication (dedup)](#step-25-optional-read-deduplication-dedup)
+- [Step 3: Host Read Removal (rm_host)](#step-3-host-read-removal-rm_host)
+- [Step 4: Resistome Analysis (resistome)](#step-4-resistome-analysis-resistome)
+- [Step 5 (Optional): Microbiome Analysis (kraken)](#step-5-optional-microbiome-analysis-kraken)
+- [Managing the Work Directory](#managing-the-work-directory)
+- [Effect of Key Parameters](#effect-of-key-parameters)
 
-# Load conda environment
-First, we have to have Anaconda or "conda" available for use. Then, we can install or load the conda environment, AMR++_env, which contains all the tools we need.
+---
 
-### Check conda installation
-Try just running conda to check if it works for you:
+## Setup
+
+### Load the Conda Environment
+
+AMR++ requires a set of bioinformatic tools that are bundled into a conda environment. You only need to create the environment once.
+
 ```bash
-conda --h
+# If you haven't installed the conda environment yet
+conda env create -f envs/AMR++_env.yaml
+
+# Activate it before each session
+conda activate AMR++_env
 ```
 
-#### Using server modules
-
-If it says `bash: conda: command not found...`, you have a few options to setup conda to work with your environment. In our university computing environment, modules are added that allow for easy access to other tools. We can run the following command:
+If your HPC uses modules to provide conda, load it first:
 
 ```bash
 module load Anaconda3/2024.02-1
-```
-
-This should load conda for you, but if it's the first time you ever do this, you'll have to run these two commands:
-```bash
-conda init
-
-source ~/.bashrc
-```
-
-#### Using miniconda
-
-If you don't have acess to conda, we recommend downloading [miniconda](https://docs.anaconda.com/miniconda/install/). This works the same as "conda" but comes in a smaller package for easier installation. 
-
-Here are the basic commands for installation:
-```bash
-mkdir -p ~/miniconda3
-wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda3/miniconda.sh
-bash ~/miniconda3/miniconda.sh -b -u -p ~/miniconda3
-rm ~/miniconda3/miniconda.sh
-```
-After installing, close and reopen your terminal application or refresh it by running the following command:
-
-```bash
-source ~/miniconda3/bin/activate
-conda init --all
-```
-
-### Install AMR++ environment
-
-Now, you should have conda installed and can install the AMR++ environment.
-
-We'll need to download the code for [AMR++ from github](https://github.com/Microbial-Ecology-Group/AMRplusplus/tree/master) using the "git" command. 
-
-```bash
-git clone https://github.com/Microbial-Ecology-Group/AMRplusplus.git
-```
-
-Let's navigate into the AMRplusplus directory and check the contents
-
-```bash
-cd AMRplusplus/
-
-ls
-```
-We have a recipe to create the conda environment in the "envs" directory. 
-
-```bash
-conda env create -f envs/AMR++_env.yaml
-# This can take 5-10 mins (or more) depending on your internet speed, computing resources, etc. 
-
-# Once it's completed, activate the environment
 conda activate AMR++_env
-
-# You now have access to all the AMR++ software dependencies (locally)
-samtools --help
 ```
 
+### Confirm Tools Are Available
 
-# Run first Demo
-
-We'll run the demonstration which will create output in the "test_results" directory. 
-
-We can run the demo with this simple command:
 ```bash
-nextflow run main_AMR++.nf
+nextflow -version
+bwa 2>&1 | head -3
+samtools --version | head -1
+trimmomatic -version
 ```
 
-Note, we don't have to specify what `--profile` to use because it defaults to using the "local" profile and just looking in your regular $PATH, whis is now modified by the conda environment, AMR++_env.
+If any of these fail, review the [installation document](installation.md) or check that your conda environment is activated.
 
-## How did AMR++ know what parameters to run:
+---
 
-AMR++ has default parameters that are listed in the `params.config` file. We can then either change the values in the file directly, or add those flags to the command you're using directly. Also, note that there are variables with a single dash "-" and others with two dashes "--". The single dashes are internal to nextflow and include parameters/flags/variables like "-profile" and "-resume". The profile flag will not change if you're using conda as instructed above, and the "-resume" flag can be added to commands when the initial run failed for some reason and you want to try picking up where it left off. Otherwise, the majority of important variables will be denoted by two dashes "--". We'll go over all the parameters used by AMR++ which we'll either change in the command or by modifying the `params.config` file.  
+## Step 1: Quality Assessment (eval_qc)
 
-Nextflow prioritizes:
-1. whatever flags you include in the command
-2. The default paramaters in `params.config`
-3. Other variable calls within AMR++
+**What it does:** Runs FastQC on all input reads and generates a MultiQC summary report so you can assess read quality before trimming.
 
-We'll practice changing various variables below. 
+**Input:** Raw paired-end FASTQ files  
+**Output:** `AMR++_results/QC_analysis/FastQC/` and `AMR++_results/QC_analysis/MultiQC_stats/multiqc_report.html`
 
-First, let's look at the defaults:
 ```bash
-less params.config 
+nextflow run main_AMR++.nf \
+    -profile local \
+    --pipeline eval_qc \
+    --reads "data/raw/*_R{1,2}.fastq.gz" \
+    --output AMR++_results
 ```
 
-For example, you can see which `--reads` are being analyzed by default and their location. We'll talk about each set of relevant variables as we go along.  
-
-# AMR++ components
-
-If the demo above completed succesfully, we are now ready run each component of the AMR++ pipeline by changing the `--pipeline` flag. Here is the list of pipelines included in AMR++. 
-
-    Available pipelines:
-        - demo: Run a demonstration of AMR++
-        - standard_AMR: Run the standard AMR++ pipeline
-        - fast_AMR: Run the fast AMR++ pipeline without host removal.
-        - standard_AMR_wKraken: Run the standard AMR++ pipeline with Kraken
-    Available pipeline subworkflows:
-        - eval_qc: Run FastQC analysis
-        - trim_qc: Run trimming and quality control
-        - rm_host: Remove host reads
-        - resistome: Perform resistome analysis
-        - align: Perform alignment to MEGARes database
-        - kraken: Perform Kraken analysis
-        - qiime2: Perform QIIME 2 analysis
-        - bam_resistome: Perform resistome analysis on BAM files
-
-    To run a specific pipeline/subworkflow, use the "--pipeline" option followed by the pipeline name:
-        nextflow run main_AMR++.nf --pipeline <pipeline_name> [other_options]
-
-# Run the eval_qc pipeline
-
-Input files for `--pipeline eval_qc`:
-* sample reads (`--reads`) (by default `--reads` = ${baseDir}/data/raw/*_R{1,2}.fastq.gz)
-
-Output files:
-* FastQC results for each sample
-* MultiQC report with aggregated results
-
-## Run first pipeline, eval_qc
-
-For this subworkflow, we'll just specify the "--pipeline" flag and add the "--output" flag to name the output folder. 
-
+**Explore the results:**
 ```bash
-nextflow run main_AMR++.nf --pipeline eval_qc --output AMR++_results 
-```
-
-
-## Explore QC results
-```bash
-ls AMR++_results/
-ls AMR++_results/QC_analysis/
 ls AMR++_results/QC_analysis/FastQC/
-ls AMR++_results/QC_analysis/FastQC/*
+# Download and open multiqc_report.html in a browser to review quality across all samples
 ```
 
-Now, let's look at the multiQC results which aggregates all these files into a single report.
-
-# Run trim_qc pipeline
-
-Input files for trim_qc:
-* sample reads (`--reads` = ${baseDir}/data/raw/*_R{1,2}.fastq.gz)
-
-Relevant default parameters:
-* `--adapters` = "${baseDir}/data/adapters/nextera.fa"
-* `--leading` = 3
-* `--trailing` = 3
-* `--slidingwindow` = "4:15"
-* `--minlen = 36`
-
-Output files:
-* Trimmed reads
-
-## trim_qc command
+**When done:** Review the MultiQC report. Look for adapter contamination, low-quality tails, or unusual GC content — these inform your trimming parameters in Step 2.
 
 ```bash
-nextflow run main_AMR++.nf --pipeline trim_qc --output AMR++_results
+# Safe to delete the work directory after confirming output
+rm -rf work/
 ```
 
+---
 
-### Download trimmomatic.stats file and open on excel
-```bash
-ls AMR++_results/QC_trimming/
+## Step 2: Quality Trimming (trim_qc)
 
-ls AMR++_results/Results/Stats/
-```
+**What it does:** Runs Trimmomatic to remove adapter sequences and low-quality bases from reads.
 
-Don't forget to delete the "work" directory.
+**Input:** Raw paired-end FASTQ files  
+**Output:**
+- `AMR++_results/QC_trimming/Paired/` — trimmed paired reads (`*.1P.fastq.gz`, `*.2P.fastq.gz`)
+- `AMR++_results/QC_trimming/Unpaired/` — reads whose pair was discarded
+- `AMR++_results/Results/Stats/trimmomatic.stats` — read counts before/after trimming
 
-```bash
-rm -r work/
-```
+**Default trimming parameters** (adjust in `params.config` or on the command line as needed):
 
-### Now, we'll talk about removing contaminant host DNA
-
-
----------------------
-
-# Run host removal pipeline
-
-
-Input files for `--pipeline rm_host` (need to change):
-* QC trimmed reads (by default `--reads` = ${baseDir}/data/raw/*_R{1,2}.fastq.gz)
-
-Relevant default parameters:
-* `--host` = "${baseDir}/data/host/chr21.fasta.gz"
-
-Output files:
-* Non-host reads
-
-
-## rm_host command
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `--adapters` | nextera.fa | Adapter sequences to remove |
+| `--leading` | 3 | Minimum quality for leading bases |
+| `--trailing` | 3 | Minimum quality for trailing bases |
+| `--slidingwindow` | 4:15 | Window size : required average quality |
+| `--minlen` | 36 | Minimum read length after trimming |
 
 ```bash
-nextflow run main_AMR++.nf --pipeline rm_host --output AMR++_results --reads "AMR++_results/QC_trimming/Paired/*{1,2}P.fastq.gz"
+nextflow run main_AMR++.nf \
+    -profile local \
+    --pipeline trim_qc \
+    --reads "data/raw/*_R{1,2}.fastq.gz" \
+    --output AMR++_results
 ```
 
-### Evaluate rm_host results
+**Inspect results:**
+```bash
+ls AMR++_results/QC_trimming/Paired/
+cat AMR++_results/Results/Stats/trimmomatic.stats
+```
+
+```bash
+rm -rf work/
+```
+
+---
+
+## Step 2.5 (Optional): Read Deduplication (dedup)
+
+**What it does:** Uses seqkit to remove exact duplicate reads by sequence. We recommend this step for **target-enriched sequencing data** (e.g., probe-based capture), where PCR duplicates are more prevalent. For standard shotgun metagenomics, this step is typically skipped.
+
+**Input:** QC-trimmed paired reads  
+**Output:** `AMR++_results/Deduped_reads/` — deduplicated reads (`*_R1.dedup.fastq.gz`, `*_R2.dedup.fastq.gz`)
+
+> **Note:** Deduplication runs on R1 and R2 independently. A read pair is removed if R1 is an exact duplicate of another R1. See the [Analysis Recommendations](Analysis_recommendations.md) for more context.
+
+```bash
+nextflow run main_AMR++.nf \
+    -profile local \
+    --pipeline dedup \
+    --reads "AMR++_results/QC_trimming/Paired/*{1,2}P.fastq.gz" \
+    --output AMR++_results
+```
+
+**Inspect results:**
+```bash
+ls AMR++_results/Deduped_reads/
+```
+
+```bash
+rm -rf work/
+```
+
+---
+
+## Step 3: Host Read Removal (rm_host)
+
+**What it does:** Aligns reads against the host genome using BWA. Reads that map to the host are discarded; unmapped reads are kept for downstream analysis.
+
+**Input:** QC-trimmed (or deduped) paired reads  
+**Output:**
+- `AMR++_results/HostRemoval/NonHostFastq/` — non-host reads (`*.non.host.R1.fastq.gz`, `*.non.host.R2.fastq.gz`)
+- `AMR++_results/Results/Stats/host.removal.stats` — read counts before/after removal
+
+**Parameters to set:**
+
+| Parameter | Description |
+|-----------|-------------|
+| `--host` | Path to your host genome FASTA. For bovine on Grace HPRC: `/scratch/group/big_scratch/SHARED_resources/host_genome/GCF_002263795.3_ARS-UCD2.0_genomic.fna` |
+| `--reads` | Point to trimmed reads (or deduped reads if you ran Step 2.5) |
+
+```bash
+# Using QC-trimmed reads
+nextflow run main_AMR++.nf \
+    -profile local \
+    --pipeline rm_host \
+    --reads "AMR++_results/QC_trimming/Paired/*{1,2}P.fastq.gz" \
+    --host /path/to/host_genome.fasta \
+    --output AMR++_results
+
+# OR using deduped reads (if you ran Step 2.5)
+nextflow run main_AMR++.nf \
+    -profile local \
+    --pipeline rm_host \
+    --reads "AMR++_results/Deduped_reads/*R{1,2}.dedup.fastq.gz" \
+    --host /path/to/host_genome.fasta \
+    --output AMR++_results
+```
+
+**Inspect results:**
 ```bash
 ls AMR++_results/HostRemoval/NonHostFastq/
-ls AMR++_results/Results/Stats/
+cat AMR++_results/Results/Stats/host.removal.stats
 ```
 
-Don't forget to delete the "work" directory.
-
 ```bash
-rm -r work/
-```
---------------------
-
-
-# Run resistome pipeline
-
-Input files for `--pipeline resistome`:
-* `--reads`
-* `--amr` = "${baseDir}/data/amr/megares_database_v3.00.fasta"
-* `--annotation` = "${baseDir}/data/amr/megares_annotations_v3.00.csv"
-
-Relevant default parameters:
-* `--threshold` = 80
-* `--min` = 5
-* `--max` = 100
-* `--skip` = 5
-* `--samples` = 1
-
-Optional parameters:
-* `--snp` = "N"
-* `--deduped` = "N"
-
-Output files:
-* Resistome analytic count matrix 
-* Rarefaction analysis and plot
-
-## resistome commmand
-
-```bash
-nextflow run main_AMR++.nf --pipeline resistome --output AMR++_results --reads "AMR++_results/HostRemoval/NonHostFastq/*R{1,2}.fastq.gz"
+rm -rf work/
 ```
 
-## Evalute resistome results
+---
+
+## Step 4: Resistome Analysis (resistome)
+
+**What it does:** Aligns reads to the MEGARes antimicrobial resistance gene database using BWA. Generates count matrices at multiple annotation levels (Type, Class, Mechanism, Group, Gene), with optional SNP confirmation and deduplication of alignments.
+
+**Input:** Non-host FASTQ files from Step 3  
+**Output:**
+- `AMR++_results/Results/AMR_analytic_matrix.csv` — standard count matrix
+- `AMR++_results/Results/SNPconfirmed_AMR_analytic_matrix.csv` — SNP-confirmed counts (if `--snp Y`)
+- `AMR++_results/Results/dedup_AMR_analytic_matrix.csv` — deduplicated counts (if `--deduped Y`)
+- `AMR++_results/ResistomeAnalysis/ResistomeCounts/` — per-sample count files
+
+**Key parameters:**
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `--threshold` | 0 | Gene fraction threshold. We recommend 0 and aggregating to Group level for analysis |
+| `--snp` | N | Set to `Y` to enable SNP confirmation for relevant genes |
+| `--deduped` | N | Set to `Y` to also output deduplicated alignment counts |
+
 ```bash
-ls AMR++_results/ResistomeAnalysis/
-ls AMR++_results/ResistomeAnalysis/Rarefaction/Figures/
+nextflow run main_AMR++.nf \
+    -profile local \
+    --pipeline resistome \
+    --reads "AMR++_results/HostRemoval/NonHostFastq/*R{1,2}.fastq.gz" \
+    --snp Y \
+    --deduped Y \
+    --output AMR++_results
+```
+
+**Inspect results:**
+```bash
 ls AMR++_results/Results/
+head AMR++_results/Results/AMR_analytic_matrix.csv
+wc -l AMR++_results/Results/AM*  # compare row counts across output matrices
 ```
-
-
-----
-# Run kraken pipeline
-
-Input files for `--pipeline rm_host`:
-* QC trimmed, nonhost sample reads (by default `--reads` = ${baseDir}/data/raw/*_R{1,2}.fastq.gz) 
-* `--kraken_db` = null
-
-Relevant default parameters:
-* `--kraken_confidence` = 0.0
-
-Output files:
-* Kraken raw output
-* Kraken classification reports
-* Aggregated kraken results for all samples
-
-## kraken command
-
-```bash 
-nextflow run main_AMR++.nf --pipeline kraken --output AMR++_results --reads "AMR++_results/HostRemoval/NonHostFastq/*R{1,2}.fastq.gz" --kraken_db "/scratch/group/vero_research/databases/kraken2/PlusPF_8/"
-```
-
-## Inspect kraken results
 
 ```bash
-ls 
+rm -rf work/
 ```
-Don't forget to delete the "work" directory.
+
+---
+
+## Step 5 (Optional): Microbiome Analysis (kraken)
+
+**What it does:** Classifies non-host reads taxonomically using Kraken2 and generates a wide-format count matrix across all samples.
+
+**Input:** Non-host FASTQ files from Step 3  
+**Output:**
+- `AMR++_results/MicrobiomeAnalysis/Kraken/` — per-sample raw and report files
+- `AMR++_results/Results/kraken_analytic_matrix.csv` — aggregated taxonomic matrix
+
+**Parameters to set:**
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `--kraken_db` | null | Path to your Kraken2 database directory |
+| `--kraken_confidence` | 0.0 | Classification confidence threshold (0–1). Higher values = fewer but more confident classifications |
+
+> **Memory note:** Kraken2 loads the entire database into RAM by default. For a large database (e.g., core_nt, ~200+ GB), ensure you are running with a SLURM `xlarge` label or equivalent memory allocation. See [Running with SLURM](Running_with_SLURM.md).
 
 ```bash
-rm -r work/
+nextflow run main_AMR++.nf \
+    -profile local \
+    --pipeline kraken \
+    --reads "AMR++_results/HostRemoval/NonHostFastq/*R{1,2}.fastq.gz" \
+    --kraken_db /path/to/kraken_db \
+    --output AMR++_results
 ```
 
-----
-# Effect of changing important parameters
+**Inspect results:**
+```bash
+head AMR++_results/Results/kraken_analytic_matrix.conf_0.0.csv
+head AMR++_results/Results/unclassifieds_kraken_analytic_matrix.conf_0.0.csv
+```
 
-Finally, let's explore how changing some of these parameters could affect our results. The two main examples are the `--threshold` flag which controls the gene fraction threshold in the resistome analysis, and the `--kraken_confidence` flag which controls how kraken classifies reads. 
+**Effect of confidence threshold:**
+```bash
+# Compare classification rates at different confidence levels
+nextflow run main_AMR++.nf \
+    -profile local \
+    --pipeline kraken \
+    --reads "AMR++_results/HostRemoval/NonHostFastq/*R{1,2}.fastq.gz" \
+    --kraken_db /path/to/kraken_db \
+    --kraken_confidence 0.5 \
+    --output AMR++_results
 
-
-## Resistome 
-
-We can rename the original reistome output AMR_analytic_matrix.csv to AMR_analytic_matrix_thresh80.csv to store the default results. Then, we can run the analysis again using a lower threshold. 
+head AMR++_results/Results/unclassifieds_kraken_analytic_matrix.conf_0.5.csv
+```
 
 ```bash
-mv AMR++_results/Results/AMR_analytic_matrix.csv AMR++_results/Results/AMR_analytic_matrix_thresh80.csv
-
-nextflow run main_AMR++.nf --pipeline resistome --output AMR++_results --reads "AMR++_results/HostRemoval/NonHostFastq/*R{1,2}.fastq.gz" --threshold 30
-
-wc -l AMR++_results/Results/AM*
+rm -rf work/
 ```
 
-Notice the increase in taxa identified with the lower threshold.
+---
 
+## Managing the Work Directory
 
-## Kraken
-Here, we can change the kraken_confidence score and run the kraken classification again. 
+As mentioned above, the `work/` directory stores all intermediate files and enables `-resume`. Here is a practical strategy for managing it:
 
 ```bash
-nextflow run main_AMR++.nf --pipeline kraken --output AMR++_results --reads "AMR++_results/HostRemoval/NonHostFastq/*R{1,2}.fastq.gz" --kraken_db "/scratch/group/vero_research/databases/kraken2/PlusPF_8/" --kraken_confidence 1
+# Check how large the work directory has grown
+du -sh work/
 
-head AMR++_results/Results/unclassifieds_kraken_analytic_matrix.conf_*
+# Delete it safely after a step completes successfully
+rm -rf work/
+
+# Redirect to a scratch drive with more space
+nextflow run main_AMR++.nf -profile local --pipeline trim_qc \
+    --reads "data/raw/*_R{1,2}.fastq.gz" \
+    -w /scratch/$USER/nf_work_trim
 ```
 
-Notice the major change in results, with a confidence of 1 leading to 100% unclassified reads.
+If a step fails partway through, use `-resume` to pick up where it left off (the work directory must still exist):
+
+```bash
+nextflow run main_AMR++.nf -profile local --pipeline rm_host \
+    --reads "AMR++_results/QC_trimming/Paired/*{1,2}P.fastq.gz" \
+    --host /path/to/host_genome.fasta \
+    --output AMR++_results \
+    -resume
+```
+
+---
+
+## Effect of Key Parameters
+
+### Gene Fraction Threshold
+
+The `--threshold` parameter controls the minimum fraction of a gene that must be covered by alignments for it to be counted. The default is 0 (count all alignments). We recommend keeping this at 0 and instead aggregating your count matrix to the **Group** level during statistical analysis to account for cross-mapping between closely related genes.
+
+```bash
+# Compare results at different thresholds
+nextflow run main_AMR++.nf --pipeline resistome \
+    --reads "AMR++_results/HostRemoval/NonHostFastq/*R{1,2}.fastq.gz" \
+    --threshold 80 --output AMR++_thresh80_results
+
+wc -l AMR++_results/Results/AMR_analytic_matrix.csv
+wc -l AMR++_thresh80_results/Results/AMR_analytic_matrix.csv
+```
+
+### Kraken Confidence
+
+```bash
+# A confidence of 1.0 will classify almost nothing — useful to see extreme
+head AMR++_results/Results/unclassifieds_kraken_analytic_matrix.conf_1.0.csv
+```
+
+See [Analysis Recommendations](Analysis_recommendations.md) for guidance on interpreting these results.

--- a/docs/Step_by_step_tutorial.md
+++ b/docs/Step_by_step_tutorial.md
@@ -238,6 +238,12 @@ wc -l AMR++_results/Results/AM*  # compare row counts across output matrices
 rm -rf work/
 ```
 
+> **Optional — tune your thresholds:** The resistome step above produces per-sample BAM files
+> (under `Alignment/BAM_files/`). If you'd like to see how your resistome results change as you
+> tighten gene-fraction and query-coverage cutoffs, and pick sensible thresholds, run the
+> [coverage threshold sweep](Coverage_sweep_tutorial.md) on those BAMs.
+
+
 ---
 
 ## Step 5 (Optional): Microbiome Analysis (kraken)

--- a/docs/Step_by_step_tutorial.md
+++ b/docs/Step_by_step_tutorial.md
@@ -126,12 +126,12 @@ rm -rf work/
 
 ## Step 2.5 (Optional): Read Deduplication (dedup)
 
-**What it does:** Uses seqkit to remove exact duplicate reads by sequence. We recommend this step for **target-enriched sequencing data** (e.g., probe-based capture), where PCR duplicates are more prevalent. For standard shotgun metagenomics, this step is typically skipped.
+**What it does:** Uses bbmap's clumpify to remove exact duplicate reads by sequence. We recommend this step for **target-enriched sequencing data** (e.g., probe-based capture), where PCR duplicates are more prevalent. For standard shotgun metagenomics, this step is typically skipped.
 
 **Input:** QC-trimmed paired reads  
 **Output:** `AMR++_results/Deduped_reads/` — deduplicated reads (`*_R1.dedup.fastq.gz`, `*_R2.dedup.fastq.gz`)
 
-> **Note:** Deduplication runs on R1 and R2 independently. A read pair is removed if R1 is an exact duplicate of another R1. See the [Analysis Recommendations](Analysis_recommendations.md) for more context.
+> **Note:** Deduplication runs on R1 and R2 together. A read pair is removed if R1 and R1 is an exact duplicate of another R1 + R2 pair. See the [Analysis Recommendations](Analysis_recommendations.md) for more context.
 
 ```bash
 nextflow run main_AMR++.nf \

--- a/envs/AMR++_env.yaml
+++ b/envs/AMR++_env.yaml
@@ -20,3 +20,8 @@ dependencies:
   - git
   - flash
   - seqkit
+  - pysam
+  - duckdb            # python duckdb
+  - r-base
+  - r-tidyverse
+  - r-data.table

--- a/main_AMR++.nf
+++ b/main_AMR++.nf
@@ -35,6 +35,7 @@ log.info """\
  Pipeline type        : ${pipelineType}
  Input (${inputParam.padRight(12)}) : ${inputPath}
  Output folder        : ${params.output}
+ Started at           : ${now}
  ===================================
 """
 
@@ -225,7 +226,7 @@ include { FASTQ_RESISTOME_SE_WF } from './subworkflows/fastq_resistome.nf'
 include { FASTQ_KRAKEN_SE_WF    } from './subworkflows/fastq_microbiome.nf'
 include { FASTQ_DEDUP_SE_WF } from './subworkflows/fastq_deduplicate.nf'
 
-// Load subworkflows
+// Load PE subworkflows
 include { FASTQ_QC_WF } from './subworkflows/fastq_information.nf'
 include { FASTQ_TRIM_WF } from './subworkflows/fastq_QC_trimming.nf'
 include { FASTQ_ALIGN_WF } from './subworkflows/fastq_align.nf'
@@ -233,6 +234,7 @@ include { FASTQ_RM_HOST_WF } from './subworkflows/fastq_host_removal.nf'
 include { FASTQ_RESISTOME_WF } from './subworkflows/fastq_resistome.nf'
 include { FASTQ_KRAKEN_WF } from './subworkflows/fastq_microbiome.nf'
 include { FASTQ_QIIME2_WF } from './subworkflows/fastq_16S_qiime2.nf'
+include { FASTQ_DEDUP_PE_WF } from './subworkflows/fastq_deduplicate.nf'
 
 // Load BAM subworkflows
 include { BAM_RESISTOME_WF } from './subworkflows/bam_resistome.nf'
@@ -321,6 +323,11 @@ workflow {
         logPipelineStart("Trimming & QC",
             "Running Trimmomatic for adapter removal and quality trimming.\n    Generates trimmed reads and QC reports.")
         FASTQ_TRIM_WF( fastq_files )
+    }
+    else if(params.pipeline == "dedup") {
+        logPipelineStart("Deduplication",
+            "Running seqKit for read deduplication.")
+        FASTQ_DEDUP_PE_WF( fastq_files )
     }
     else if(params.pipeline == "rm_host") {
         logPipelineStart("Host Removal",
@@ -423,29 +430,35 @@ workflow {
         logPipelineStart("Read Merging",
             "Merging paired-end reads with FLASH.\n    Generates merged and unmerged read files.")
         FASTQ_MERGE_WF( fastq_files )
+    } 
+    else if(params.pipeline == "merge_reads") {
+        logPipelineStart("Read Merging",
+            "Merging paired-end reads with FLASH.\n    Generates merged and unmerged read files.")
+        Channel
+          .fromFilePairs( params.merged_reads, glob: true )
+          .ifEmpty { error "No FASTQ files match: ${params.merged_reads}" }
+          .map { sample_id, files ->
+            def merged   = files.find { it.name.contains('merged')   }
+            def unmerged = files.find { it.name.contains('unmerged') }
+            assert merged && unmerged : "Sample $sample_id missing one of merged/unmerged"
+            tuple( sample_id, merged, unmerged )
+          }
+          .set { to_dedup_ch }
+        FASTQ_DEDUP_MERGED_WF( to_dedup_ch )
     }  
     else if(params.pipeline == "merged_rm_host") {
         logPipelineStart("Merged Reads Host Removal",
             "Removing host reads from merged paired-end data.\n    Host genome: ${params.host}")
         Channel
-            .fromPath( params.merged_reads, glob:true )
-            .ifEmpty { error "No FASTQs match: ${params.merged_reads}" }
-            .map { f ->
-                def m = (f.name =~ /(.+?).(extendedFrags|notCombined)\.fastq\.gz$/)
-                if( !m ) error "Unrecognised FLASH name: ${f.name}"
-                def sid   = m[0][1]
-                def rtype = m[0][2]
-                tuple( sid, tuple(rtype, f) )
-            }
-            .groupTuple()
-            .map { sid, list ->
-                def merged_fq   = list.find { it[0] == 'extendedFrags' }?.getAt(1)
-                def unmerged_fq = list.find { it[0] == 'notCombined'   }?.getAt(1)
-                if( !merged_fq || !unmerged_fq )
-                    error "Sample ${sid} is missing merged or unmerged FASTQ"
-                tuple( sid, merged_fq, unmerged_fq )
-            }
-            .set { to_host_rm_ch }
+          .fromFilePairs( params.merged_reads, glob: true )
+          .ifEmpty { error "No FASTQ files match: ${params.merged_reads}" }
+          .map { sample_id, files ->
+            def merged   = files.find { it.name.contains('merged')   }
+            def unmerged = files.find { it.name.contains('unmerged') }
+            assert merged && unmerged : "Sample $sample_id missing one of merged/unmerged"
+            tuple( sample_id, merged, unmerged )
+          }
+          .set { to_host_rm_ch }
         MERGED_FASTQ_RM_HOST_WF(params.host, to_host_rm_ch)
     }  
     else if(params.pipeline == "merged_resistome") {
@@ -542,6 +555,7 @@ workflow.onComplete {
     Success         : ${workflow.success}
     Work directory  : ${workflow.workDir}
     Output directory: ${params.output}
+    Exit status     : ${workflow.exitStatus}
     ===============================================================================
     """
 }

--- a/main_AMR++.nf
+++ b/main_AMR++.nf
@@ -13,6 +13,7 @@ nextflow.enable.dsl=2
 def pipelineType = "Paired-end"
 def inputParam = "--reads"
 def inputPath = params.reads
+def now = new java.util.Date().format("yyyy-MM-dd HH:mm:ss")
 
 if (params.pipeline?.startsWith("se_") || params.pipeline == "se_AMR") {
     pipelineType = "Single-end"

--- a/main_AMR++.nf
+++ b/main_AMR++.nf
@@ -223,7 +223,7 @@ include { FASTQ_TRIM_SE_WF } from './subworkflows/fastq_QC_trimming.nf'
 include { FASTQ_RM_HOST_SE_WF   } from './subworkflows/fastq_host_removal.nf'
 include { FASTQ_RESISTOME_SE_WF } from './subworkflows/fastq_resistome.nf'
 include { FASTQ_KRAKEN_SE_WF    } from './subworkflows/fastq_microbiome.nf'
-
+include { FASTQ_DEDUP_SE_WF } from './subworkflows/fastq_deduplicate.nf'
 
 // Load subworkflows
 include { FASTQ_QC_WF } from './subworkflows/fastq_information.nf'
@@ -366,7 +366,7 @@ workflow {
             "Running FastQC analysis on single-end reads.")
         Channel
             .fromPath(params.reads)
-            .map { f -> tuple(f.baseName, f) }
+            .map { f -> tuple(f.simpleName, f) }
             .set { read_se_ch }
         FASTQ_QC_SE_WF( read_se_ch )
     }
@@ -375,16 +375,25 @@ workflow {
             "Running Trimmomatic on single-end reads.")
         Channel
             .fromPath(params.reads)
-            .map { f -> tuple(f.baseName, f) }
+            .map { f -> tuple(f.simpleName, f) }
             .set { read_se_ch }
         FASTQ_TRIM_SE_WF( read_se_ch )
+    }
+    else if(params.pipeline == "se_dedup") {
+        logPipelineStart("Single-End QC Evaluation",
+            "Running read deduplication on single-end reads.")
+        Channel
+            .fromPath(params.reads)
+            .map { f -> tuple(f.simpleName, f) }
+            .set { read_se_ch }
+        FASTQ_DEDUP_SE_WF( read_se_ch )
     }
     else if(params.pipeline == "se_rm_host") {
         logPipelineStart("Single-End Host Removal",
             "Removing host reads from single-end data.\n    Host genome: ${params.host}")
         Channel
             .fromPath(params.reads)
-            .map { f -> tuple(f.baseName, f) }
+            .map { f -> tuple(f.simpleName, f) }
             .set { read_se_ch }
         FASTQ_RM_HOST_SE_WF( params.host, read_se_ch )
     }
@@ -393,7 +402,7 @@ workflow {
             "Performing resistome analysis on single-end reads.")
         Channel
             .fromPath(params.reads)
-            .map { f -> tuple(f.baseName, f) }
+            .map { f -> tuple(f.simpleName, f) }
             .set { read_se_ch }
         FASTQ_RESISTOME_SE_WF( read_se_ch , params.amr, params.annotation )
     }
@@ -402,7 +411,7 @@ workflow {
             "Running Kraken2 on single-end reads.\n    Database: ${params.kraken_db}")
         Channel
             .fromPath(params.reads)
-            .map { f -> tuple(f.baseName, f) }
+            .map { f -> tuple(f.simpleName, f) }
             .set { read_se_ch }
         FASTQ_KRAKEN_SE_WF( read_se_ch )
     }

--- a/main_AMR++.nf
+++ b/main_AMR++.nf
@@ -81,6 +81,7 @@ def helpMessage = """\
 
     eval_qc                 Run FastQC quality assessment
     trim_qc                 Run trimming and quality control (Trimmomatic)
+    dedup                   Run read de-duplication with SeqKit
     rm_host                 Remove host reads (BWA alignment to host genome)
     resistome               Perform resistome analysis (alignment + counting)
     align                   Perform alignment to MEGARes database only
@@ -94,6 +95,7 @@ def helpMessage = """\
 
     se_eval_qc              FastQC for single-end reads
     se_trim_qc              Trimming for single-end reads
+    se_dedup                Run read de-duplication with SeqKit
     se_rm_host              Host removal for single-end reads
     se_resistome            Resistome analysis for single-end reads
     se_kraken               Kraken analysis for single-end reads

--- a/main_AMR++.nf
+++ b/main_AMR++.nf
@@ -228,6 +228,7 @@ include { STANDARD_AMRplusplus_wKraken } from './subworkflows/AMR++_standard_wKr
 include { STANDARD_merged_AMRplusplus } from './subworkflows/AMR++_merged_standard.nf'
 include { STANDARD_merged_AMRplusplus_wKraken } from './subworkflows/AMR++_merged_standard_wKraken.nf'
 include { FASTQ_MERGE_WF } from './subworkflows/fastq_merging.nf'
+include { FASTQ_DEDUP_MERGED_WF } from './subworkflows/fastq_deduplicate.nf'
 include { MERGED_FASTQ_RM_HOST_WF } from './subworkflows/fastq_host_removal.nf'
 include { MERGED_FASTQ_ALIGN_WF } from './subworkflows/fastq_align.nf' 
 include { MERGED_FASTQ_RESISTOME_WF } from './subworkflows/fastq_resistome.nf'
@@ -238,11 +239,11 @@ include { SE_AMRplusplus } from './subworkflows/AMR++_SE_standard.nf'
 include { SE_AMRplusplus_wKraken } from './subworkflows/AMR++_SE_standard_wKraken.nf'
 include { FASTQ_QC_SE_WF } from './subworkflows/fastq_information.nf'
 include { FASTQ_TRIM_SE_WF } from './subworkflows/fastq_QC_trimming.nf'
+include { FASTQ_DEDUP_SE_WF } from './subworkflows/fastq_deduplicate.nf'
 include { FASTQ_RM_HOST_SE_WF   } from './subworkflows/fastq_host_removal.nf'
 include { SE_FASTQ_ALIGN_WF } from './subworkflows/fastq_align.nf'
 include { FASTQ_RESISTOME_SE_WF } from './subworkflows/fastq_resistome.nf'
 include { FASTQ_KRAKEN_SE_WF    } from './subworkflows/fastq_microbiome.nf'
-
 
 // Load subworkflows
 include { FASTQ_QC_WF } from './subworkflows/fastq_information.nf'
@@ -252,6 +253,7 @@ include { FASTQ_RM_HOST_WF } from './subworkflows/fastq_host_removal.nf'
 include { FASTQ_RESISTOME_WF } from './subworkflows/fastq_resistome.nf'
 include { FASTQ_KRAKEN_WF } from './subworkflows/fastq_microbiome.nf'
 include { FASTQ_QIIME2_WF } from './subworkflows/fastq_16S_qiime2.nf'
+include { FASTQ_DEDUP_PE_WF } from './subworkflows/fastq_deduplicate.nf'
 
 // Load BAM subworkflows
 include { BAM_RESISTOME_WF } from './subworkflows/bam_resistome.nf'
@@ -358,6 +360,11 @@ workflow {
             "Running Trimmomatic for adapter removal and quality trimming.\n    Generates trimmed reads and QC reports.")
         FASTQ_TRIM_WF( fastq_files )
     }
+    else if(params.pipeline == "dedup") {
+        logPipelineStart("Deduplication",
+            "Deduplicating paired end reads.\n    Generates deduped fastq reads.")
+        FASTQ_DEDUP_PE_WF( fastq_files )
+    }
     else if(params.pipeline == "rm_host") {
         logPipelineStart("Host Removal",
             "Removing host-derived reads using BWA alignment.\n    Host genome: ${params.host}")
@@ -414,6 +421,11 @@ workflow {
             .map { f -> tuple(f.simpleName, f) }
             .set { read_se_ch }
         FASTQ_TRIM_SE_WF( read_se_ch )
+    }
+    else if(params.pipeline == "se_dedup") {
+        logPipelineStart("Deduplication",
+            "Deduplicating single end reads.\n    Generates deduped single-end fastq reads.")
+        FASTQ_DEDUP_SE_WF( fastq_files )
     }
     else if(params.pipeline == "se_rm_host") {
         logPipelineStart("Single-End Host Removal",

--- a/main_AMR++.nf
+++ b/main_AMR++.nf
@@ -9,39 +9,56 @@ nextflow.enable.dsl=2
  * given `params.foo` specify on the run command line `--foo some_value`.
 */
 
-// Determine pipeline type and input source
-def pipelineType = "Paired-end"
-def inputParam = "--reads"
-def inputPath = params.reads
-def now = new java.util.Date().format("yyyy-MM-dd HH:mm:ss")
+// =============================================================================
+//  Helper functions
+//  NOTE: All executable logic lives in functions or inside the entry workflow
+//  block below. Top-level statements (variable assignments, Channel pipelines,
+//  if/else chains) cannot be mixed with top-level declarations (process,
+//  workflow, include) under Nextflow's strict syntax parser. Writing it this
+//  way is compatible with both the classic (v1) and strict (v2) parsers.
+// =============================================================================
 
-if (params.pipeline?.startsWith("se_") || params.pipeline == "se_AMR") {
-    pipelineType = "Single-end"
-    inputParam = "--reads"
-    inputPath = params.reads
-} else if (params.pipeline?.startsWith("merged_") || params.pipeline == "merged_AMR" || params.pipeline == "merged_AMR_wKraken") {
-    pipelineType = "Merged reads"
-    inputParam = "--merged_reads"
-    inputPath = params.merged_reads ?: params.reads
-} else if (params.pipeline?.startsWith("bam_")) {
-    pipelineType = "BAM files"
-    inputParam = "--bam_files"
-    inputPath = params.bam_files ?: "Not specified"
+def getPipelineInfo() {
+    def pipelineType = "Paired-end"
+    def inputParam = "--reads"
+    def inputPath = params.reads
+
+    if (params.pipeline?.startsWith("se_") || params.pipeline == "se_AMR") {
+        pipelineType = "Single-end"
+        inputParam = "--reads"
+        inputPath = params.reads
+    } else if (params.pipeline?.startsWith("merged_") || params.pipeline == "merged_AMR" || params.pipeline == "merged_AMR_wKraken") {
+        pipelineType = "Merged reads"
+        inputParam = "--merged_reads"
+        inputPath = params.merged_reads ?: params.reads
+    } else if (params.pipeline?.startsWith("bam_")) {
+        pipelineType = "BAM files"
+        inputParam = "--bam_files"
+        inputPath = params.bam_files ?: "Not specified"
+    }
+
+    return [pipelineType, inputParam, inputPath]
 }
 
-log.info """\
+def printPipelineBanner() {
+    def info = getPipelineInfo()
+    def pipelineType = info[0]
+    def inputParam   = info[1]
+    def inputPath    = info[2]
+
+    log.info """\
  A M R + +    N F   P I P E L I N E
  ===================================
  Pipeline             : ${params.pipeline ?: 'demo'}
  Pipeline type        : ${pipelineType}
  Input (${inputParam.padRight(12)}) : ${inputPath}
  Output folder        : ${params.output}
- Started at           : ${now}
  ===================================
 """
+}
 
-
-def helpMessage = """\
+def helpMessage() {
+    return """\
     ===============================================================================
                         AMR++ Nextflow Pipeline Help
     ===============================================================================
@@ -81,7 +98,6 @@ def helpMessage = """\
 
     eval_qc                 Run FastQC quality assessment
     trim_qc                 Run trimming and quality control (Trimmomatic)
-    dedup                   Run read de-duplication with SeqKit
     rm_host                 Remove host reads (BWA alignment to host genome)
     resistome               Perform resistome analysis (alignment + counting)
     align                   Perform alignment to MEGARes database only
@@ -95,7 +111,6 @@ def helpMessage = """\
 
     se_eval_qc              FastQC for single-end reads
     se_trim_qc              Trimming for single-end reads
-    se_dedup                Run read de-duplication with SeqKit
     se_rm_host              Host removal for single-end reads
     se_resistome            Resistome analysis for single-end reads
     se_kraken               Kraken analysis for single-end reads
@@ -185,6 +200,7 @@ def helpMessage = """\
     For more information, visit: https://github.com/Microbial-Ecology-Group/AMRplusplus
     ===============================================================================
     """
+}
 
 // Helper function for consistent pipeline logging
 def logPipelineStart(String pipelineName, String description) {
@@ -197,14 +213,9 @@ def logPipelineStart(String pipelineName, String description) {
     """
 }
 
-Channel
-    .fromFilePairs( params.reads , size: (params.reads =~ /\{/) ? 2 : 1)
-    .ifEmpty { error "Cannot find any reads matching: ${params.reads}" }
-    .map { id, files -> 
-        def modified_baseName = id.split('\\.')[0]
-        tuple(modified_baseName, files)
-    }
-    .set {fastq_files}
+// =============================================================================
+//  Includes (declarations -- always allowed at top level)
+// =============================================================================
 
 // Load main pipeline workflows
 include { STANDARD_AMRplusplus } from './subworkflows/AMR++_standard.nf' 
@@ -227,9 +238,9 @@ include { FASTQ_TRIM_SE_WF } from './subworkflows/fastq_QC_trimming.nf'
 include { FASTQ_RM_HOST_SE_WF   } from './subworkflows/fastq_host_removal.nf'
 include { FASTQ_RESISTOME_SE_WF } from './subworkflows/fastq_resistome.nf'
 include { FASTQ_KRAKEN_SE_WF    } from './subworkflows/fastq_microbiome.nf'
-include { FASTQ_DEDUP_SE_WF } from './subworkflows/fastq_deduplicate.nf'
 
-// Load PE subworkflows
+
+// Load subworkflows
 include { FASTQ_QC_WF } from './subworkflows/fastq_information.nf'
 include { FASTQ_TRIM_WF } from './subworkflows/fastq_QC_trimming.nf'
 include { FASTQ_ALIGN_WF } from './subworkflows/fastq_align.nf'
@@ -237,20 +248,36 @@ include { FASTQ_RM_HOST_WF } from './subworkflows/fastq_host_removal.nf'
 include { FASTQ_RESISTOME_WF } from './subworkflows/fastq_resistome.nf'
 include { FASTQ_KRAKEN_WF } from './subworkflows/fastq_microbiome.nf'
 include { FASTQ_QIIME2_WF } from './subworkflows/fastq_16S_qiime2.nf'
-include { FASTQ_DEDUP_PE_WF } from './subworkflows/fastq_deduplicate.nf'
 
 // Load BAM subworkflows
 include { BAM_RESISTOME_WF } from './subworkflows/bam_resistome.nf'
 include { BAM_RESISTOME_COUNTS_WF } from './subworkflows/bam_resistome_counts.nf'
 
 
+// =============================================================================
+//  Entry workflow
+//  All executable statements (Channel pipelines, if/else routing, onComplete)
+//  live inside this block.
+// =============================================================================
 
 workflow {
+
+    printPipelineBanner()
+
+    Channel
+        .fromFilePairs( params.reads , size: (params.reads =~ /\{/) ? 2 : 1)
+        .ifEmpty { error "Cannot find any reads matching: ${params.reads}" }
+        .map { id, files -> 
+            def modified_baseName = id.split('\\.')[0]
+            tuple(modified_baseName, files)
+        }
+        .set { fastq_files }
+
     // =========================================================================
     //                          HELP / DEFAULT
     // =========================================================================
     if (params.pipeline == null || params.pipeline == "help") {
-        println helpMessage
+        println helpMessage()
         FAST_AMRplusplus(fastq_files, params.amr, params.annotation)
     }
 
@@ -327,11 +354,6 @@ workflow {
             "Running Trimmomatic for adapter removal and quality trimming.\n    Generates trimmed reads and QC reports.")
         FASTQ_TRIM_WF( fastq_files )
     }
-    else if(params.pipeline == "dedup") {
-        logPipelineStart("Deduplication",
-            "Running seqKit for read deduplication.")
-        FASTQ_DEDUP_PE_WF( fastq_files )
-    }
     else if(params.pipeline == "rm_host") {
         logPipelineStart("Host Removal",
             "Removing host-derived reads using BWA alignment.\n    Host genome: ${params.host}")
@@ -389,15 +411,6 @@ workflow {
             .set { read_se_ch }
         FASTQ_TRIM_SE_WF( read_se_ch )
     }
-    else if(params.pipeline == "se_dedup") {
-        logPipelineStart("Single-End QC Evaluation",
-            "Running read deduplication on single-end reads.")
-        Channel
-            .fromPath(params.reads)
-            .map { f -> tuple(f.simpleName, f) }
-            .set { read_se_ch }
-        FASTQ_DEDUP_SE_WF( read_se_ch )
-    }
     else if(params.pipeline == "se_rm_host") {
         logPipelineStart("Single-End Host Removal",
             "Removing host reads from single-end data.\n    Host genome: ${params.host}")
@@ -433,35 +446,29 @@ workflow {
         logPipelineStart("Read Merging",
             "Merging paired-end reads with FLASH.\n    Generates merged and unmerged read files.")
         FASTQ_MERGE_WF( fastq_files )
-    } 
-    else if(params.pipeline == "merge_reads") {
-        logPipelineStart("Read Merging",
-            "Merging paired-end reads with FLASH.\n    Generates merged and unmerged read files.")
-        Channel
-          .fromFilePairs( params.merged_reads, glob: true )
-          .ifEmpty { error "No FASTQ files match: ${params.merged_reads}" }
-          .map { sample_id, files ->
-            def merged   = files.find { it.name.contains('merged')   }
-            def unmerged = files.find { it.name.contains('unmerged') }
-            assert merged && unmerged : "Sample $sample_id missing one of merged/unmerged"
-            tuple( sample_id, merged, unmerged )
-          }
-          .set { to_dedup_ch }
-        FASTQ_DEDUP_MERGED_WF( to_dedup_ch )
     }  
     else if(params.pipeline == "merged_rm_host") {
         logPipelineStart("Merged Reads Host Removal",
             "Removing host reads from merged paired-end data.\n    Host genome: ${params.host}")
         Channel
-          .fromFilePairs( params.merged_reads, glob: true )
-          .ifEmpty { error "No FASTQ files match: ${params.merged_reads}" }
-          .map { sample_id, files ->
-            def merged   = files.find { it.name.contains('merged')   }
-            def unmerged = files.find { it.name.contains('unmerged') }
-            assert merged && unmerged : "Sample $sample_id missing one of merged/unmerged"
-            tuple( sample_id, merged, unmerged )
-          }
-          .set { to_host_rm_ch }
+            .fromPath( params.merged_reads, glob:true )
+            .ifEmpty { error "No FASTQs match: ${params.merged_reads}" }
+            .map { f ->
+                def m = (f.name =~ /(.+?).(extendedFrags|notCombined)\.fastq\.gz$/)
+                if( !m ) error "Unrecognised FLASH name: ${f.name}"
+                def sid   = m[0][1]
+                def rtype = m[0][2]
+                tuple( sid, tuple(rtype, f) )
+            }
+            .groupTuple()
+            .map { sid, list ->
+                def merged_fq   = list.find { it[0] == 'extendedFrags' }?.getAt(1)
+                def unmerged_fq = list.find { it[0] == 'notCombined'   }?.getAt(1)
+                if( !merged_fq || !unmerged_fq )
+                    error "Sample ${sid} is missing merged or unmerged FASTQ"
+                tuple( sid, merged_fq, unmerged_fq )
+            }
+            .set { to_host_rm_ch }
         MERGED_FASTQ_RM_HOST_WF(params.host, to_host_rm_ch)
     }  
     else if(params.pipeline == "merged_resistome") {
@@ -540,14 +547,18 @@ workflow {
     Run with --pipeline help to see all available options.
     ===============================================================================
         """
-        println helpMessage
+        println helpMessage()
         System.exit(1)  
     }
-}
 
-
-workflow.onComplete {
-    log.info """
+    // =========================================================================
+    //                         ON COMPLETE HANDLER
+    //  Moved inside the entry workflow -- a bare `workflow.onComplete {}` at
+    //  the top level is itself a statement and is rejected by the strict
+    //  parser for the same reason as everything else above.
+    // =========================================================================
+    workflow.onComplete {
+        log.info """
     ===============================================================================
                             Pipeline Complete
     ===============================================================================
@@ -558,7 +569,7 @@ workflow.onComplete {
     Success         : ${workflow.success}
     Work directory  : ${workflow.workDir}
     Output directory: ${params.output}
-    Exit status     : ${workflow.exitStatus}
     ===============================================================================
     """
+    }
 }

--- a/main_AMR++.nf
+++ b/main_AMR++.nf
@@ -112,6 +112,7 @@ def helpMessage() {
     se_eval_qc              FastQC for single-end reads
     se_trim_qc              Trimming for single-end reads
     se_rm_host              Host removal for single-end reads
+    se_align                Perform alignment to MEGARes database for single-end reads
     se_resistome            Resistome analysis for single-end reads
     se_kraken               Kraken analysis for single-end reads
 
@@ -122,6 +123,7 @@ def helpMessage() {
 
     merge_reads             Merge paired-end reads with FLASH
     merged_rm_host          Host removal for merged reads
+    merged_align            Perform alignment to MEGARes database only for merged reads
     merged_resistome        Resistome analysis for merged reads
     merged_kraken           Kraken analysis for merged reads
 
@@ -226,7 +228,8 @@ include { STANDARD_AMRplusplus_wKraken } from './subworkflows/AMR++_standard_wKr
 include { STANDARD_merged_AMRplusplus } from './subworkflows/AMR++_merged_standard.nf'
 include { STANDARD_merged_AMRplusplus_wKraken } from './subworkflows/AMR++_merged_standard_wKraken.nf'
 include { FASTQ_MERGE_WF } from './subworkflows/fastq_merging.nf'
-include { MERGED_FASTQ_RM_HOST_WF } from './subworkflows/fastq_host_removal.nf' 
+include { MERGED_FASTQ_RM_HOST_WF } from './subworkflows/fastq_host_removal.nf'
+include { MERGED_FASTQ_ALIGN_WF } from './subworkflows/fastq_align.nf' 
 include { MERGED_FASTQ_RESISTOME_WF } from './subworkflows/fastq_resistome.nf'
 include { MERGED_FASTQ_KRAKEN_WF } from './subworkflows/fastq_microbiome.nf'
 
@@ -236,6 +239,7 @@ include { SE_AMRplusplus_wKraken } from './subworkflows/AMR++_SE_standard_wKrake
 include { FASTQ_QC_SE_WF } from './subworkflows/fastq_information.nf'
 include { FASTQ_TRIM_SE_WF } from './subworkflows/fastq_QC_trimming.nf'
 include { FASTQ_RM_HOST_SE_WF   } from './subworkflows/fastq_host_removal.nf'
+include { SE_FASTQ_ALIGN_WF } from './subworkflows/fastq_align.nf'
 include { FASTQ_RESISTOME_SE_WF } from './subworkflows/fastq_resistome.nf'
 include { FASTQ_KRAKEN_SE_WF    } from './subworkflows/fastq_microbiome.nf'
 
@@ -420,6 +424,15 @@ workflow {
             .set { read_se_ch }
         FASTQ_RM_HOST_SE_WF( params.host, read_se_ch )
     }
+    else if(params.pipeline == "se_align") {
+        logPipelineStart("Alignment Only",
+            "Aligning reads to MEGARes database with BWA.\n    Generates BAM files for downstream analysis.")
+        Channel
+            .fromPath(params.reads)
+            .map { f -> tuple(f.simpleName, f) }
+            .set { read_se_ch }
+        SE_FASTQ_ALIGN_WF( read_se_ch, params.amr)
+    }  
     else if(params.pipeline == "se_resistome") {
         logPipelineStart("Single-End Resistome",
             "Performing resistome analysis on single-end reads.")
@@ -470,6 +483,21 @@ workflow {
             }
             .set { to_host_rm_ch }
         MERGED_FASTQ_RM_HOST_WF(params.host, to_host_rm_ch)
+    }  
+    else if(params.pipeline == "merged_align") {
+        logPipelineStart("Alignment Only",
+            "Aligning reads to MEGARes database with BWA.\n    Generates BAM files for downstream analysis.")
+        Channel
+          .fromFilePairs( params.merged_reads, glob: true )
+          .ifEmpty { error "No FASTQ files match: ${params.merged_reads}" }
+          .map { sample_id, files ->
+            def merged   = files.find { it.name.contains('merged')   }
+            def unmerged = files.find { it.name.contains('unmerged') }
+            assert merged && unmerged : "Sample $sample_id missing one of merged/unmerged"
+            tuple( sample_id, merged, unmerged )
+          }
+          .set { to_align_ch }
+        MERGED_FASTQ_ALIGN_WF( to_align_ch, params.amr)
     }  
     else if(params.pipeline == "merged_resistome") {
         logPipelineStart("Merged Reads Resistome",

--- a/main_AMR++.nf
+++ b/main_AMR++.nf
@@ -585,7 +585,7 @@ workflow {
     //  the top level is itself a statement and is rejected by the strict
     //  parser for the same reason as everything else above.
     // =========================================================================
-    workflow.onComplete {
+    workflow.onComplete = {
         log.info """
     ===============================================================================
                             Pipeline Complete

--- a/main_AMR++.nf
+++ b/main_AMR++.nf
@@ -214,10 +214,10 @@ include { STANDARD_AMRplusplus_wKraken } from './subworkflows/AMR++_standard_wKr
 // Load merged read workflows
 include { STANDARD_merged_AMRplusplus } from './subworkflows/AMR++_merged_standard.nf'
 include { STANDARD_merged_AMRplusplus_wKraken } from './subworkflows/AMR++_merged_standard_wKraken.nf'
-include { FASTQ_MERGE_WF } from "$baseDir/subworkflows/fastq_merging.nf"
-include { MERGED_FASTQ_RM_HOST_WF } from "$baseDir/subworkflows/fastq_host_removal.nf" 
-include { MERGED_FASTQ_RESISTOME_WF } from "$baseDir/subworkflows/fastq_resistome.nf"
-include { MERGED_FASTQ_KRAKEN_WF } from "$baseDir/subworkflows/fastq_microbiome.nf"
+include { FASTQ_MERGE_WF } from './subworkflows/fastq_merging.nf'
+include { MERGED_FASTQ_RM_HOST_WF } from './subworkflows/fastq_host_removal.nf' 
+include { MERGED_FASTQ_RESISTOME_WF } from './subworkflows/fastq_resistome.nf'
+include { MERGED_FASTQ_KRAKEN_WF } from './subworkflows/fastq_microbiome.nf'
 
 // Load SE read workflows
 include { SE_AMRplusplus } from './subworkflows/AMR++_SE_standard.nf'

--- a/main_AMR++.nf
+++ b/main_AMR++.nf
@@ -603,11 +603,6 @@ workflow {
     }
 
     // =========================================================================
-    //                         ON COMPLETE HANDLER
-    //  Moved inside the entry workflow -- a bare `workflow.onComplete {}` at
-    //  the top level is itself a statement and is rejected by the strict
-    //  parser for the same reason as everything else above.
-    // =========================================================================
     workflow.onComplete = {
         log.info """
     ===============================================================================

--- a/main_AMR++.nf
+++ b/main_AMR++.nf
@@ -134,6 +134,7 @@ def helpMessage() {
 
     bam_resistome           Resistome analysis from BAM files
     bam_resistome_counts    Resistome counting from BAM files
+    bam_coverage_sweep      Per-BAM coverage threshold sweep + dropoff summary
 
     -------------------------------------------------------------------------------
                               OPTIONS
@@ -258,7 +259,7 @@ include { FASTQ_DEDUP_PE_WF } from './subworkflows/fastq_deduplicate.nf'
 // Load BAM subworkflows
 include { BAM_RESISTOME_WF } from './subworkflows/bam_resistome.nf'
 include { BAM_RESISTOME_COUNTS_WF } from './subworkflows/bam_resistome_counts.nf'
-
+include { BAM_COVERAGE_SWEEP_WF } from './subworkflows/bam_resistome.nf'
 
 // =============================================================================
 //  Entry workflow
@@ -570,6 +571,16 @@ workflow {
             }
             .set {bam_files_ch}
         BAM_RESISTOME_COUNTS_WF( bam_files_ch , params.amr, params.annotation )
+    }
+    else if(params.pipeline == "bam_coverage_sweep"){
+        logPipelineStart("BAM Coverage Threshold Sweep",
+            "Per-BAM coverage_threshold_sweep.py + plot_sweep_dropoff.R summary.\n    Input: ${params.bam_files}")
+        Channel
+            .fromPath(params.bam_files)
+            .ifEmpty { exit 1, "BAM files could not be found: ${params.bam_files}" }
+            .map { file -> tuple(file.baseName.split('\\.')[0], file) }
+            .set { bam_files_ch }
+        BAM_COVERAGE_SWEEP_WF( bam_files_ch )
     }
 
     // =========================================================================

--- a/modules/Alignment/bwa.nf
+++ b/modules/Alignment/bwa.nf
@@ -11,10 +11,6 @@ if( params.annotation ) {
 }
 
 
-threads = params.threads
-samtools_flag = params.samtools_flag
-deduped = params.deduped
-
 process index {
     tag "Creating bwa index"
     label "micro"
@@ -61,29 +57,29 @@ process bwa_align {
         tuple val(pair_id), path("${pair_id}_alignment_dedup.bam"), emit: bwa_dedup_bam, optional: true
 
     script:
-    if( deduped == "N")
+    if( ${params.deduped} == "N")
         """
-        ${BWA} mem ${indexfiles[0]} ${reads} -t ${threads} -R '@RG\\tID:${pair_id}\\tSM:${pair_id}' > ${pair_id}_alignment.sam
-        ${SAMTOOLS} view -@ ${threads} -S -b ${samtools_flag} ${pair_id}_alignment.sam > ${pair_id}_alignment.bam
+        ${BWA} mem ${indexfiles[0]} ${reads} -t ${task.cpus} -R '@RG\\tID:${pair_id}\\tSM:${pair_id}' > ${pair_id}_alignment.sam
+        ${SAMTOOLS} view -@ ${task.cpus} -S -b ${params.samtools_flag} ${pair_id}_alignment.sam > ${pair_id}_alignment.bam
         rm ${pair_id}_alignment.sam
-        ${SAMTOOLS} sort -@ ${threads} -n ${pair_id}_alignment.bam -o ${pair_id}_alignment_sorted.bam
+        ${SAMTOOLS} sort -@ ${task.cpus} -n ${pair_id}_alignment.bam -o ${pair_id}_alignment_sorted.bam
         rm ${pair_id}_alignment.bam
         """
-    else if( deduped == "Y")
+    else if( ${params.deduped} == "Y")
         """
-        ${BWA} mem ${indexfiles[0]} ${reads} -t ${threads} -R '@RG\\tID:${pair_id}\\tSM:${pair_id}' > ${pair_id}_alignment.sam
-        ${SAMTOOLS} view -@ ${threads} -S -b ${samtools_flag} ${pair_id}_alignment.sam > ${pair_id}_alignment.bam
+        ${BWA} mem ${indexfiles[0]} ${reads} -t ${task.cpus} -R '@RG\\tID:${pair_id}\\tSM:${pair_id}' > ${pair_id}_alignment.sam
+        ${SAMTOOLS} view -@ ${task.cpus} -S -b ${params.samtools_flag} ${pair_id}_alignment.sam > ${pair_id}_alignment.bam
         rm ${pair_id}_alignment.sam
-        ${SAMTOOLS} sort -@ ${threads} -n ${pair_id}_alignment.bam -o ${pair_id}_alignment_sorted.bam
+        ${SAMTOOLS} sort -@ ${task.cpus} -n ${pair_id}_alignment.bam -o ${pair_id}_alignment_sorted.bam
         rm ${pair_id}_alignment.bam
-        ${SAMTOOLS} fixmate -@ ${threads} -m ${pair_id}_alignment_sorted.bam ${pair_id}_alignment_sorted_fix.bam
-        ${SAMTOOLS} sort -@ ${threads} ${pair_id}_alignment_sorted_fix.bam -o ${pair_id}_alignment_sorted_fix.sorted.bam
+        ${SAMTOOLS} fixmate -@ ${task.cpus} -m ${pair_id}_alignment_sorted.bam ${pair_id}_alignment_sorted_fix.bam
+        ${SAMTOOLS} sort -@ ${task.cpus} ${pair_id}_alignment_sorted_fix.bam -o ${pair_id}_alignment_sorted_fix.sorted.bam
         rm ${pair_id}_alignment_sorted_fix.bam
         ${SAMTOOLS} markdup -r ${pair_id}_alignment_sorted_fix.sorted.bam ${pair_id}_alignment_dedup.bam
         rm ${pair_id}_alignment_sorted_fix.sorted.bam
         """
     else
-        error "Invalid deduplication flag --deduped: ${deduped}. Please use --deduped Y for deduplicated counts, or avoid using this flag altogether to skip this error."
+        error "Invalid deduplication flag --deduped: ${params.deduped}. Please use --deduped Y for deduplicated counts, or avoid using this flag altogether to skip this error."
 }
 
 process bwa_merged_align {
@@ -119,7 +115,7 @@ process bwa_merged_align {
 
     script:
     def cpu = task.cpus ?: threads
-    if (deduped == 'N') """
+    if (${params.deduped} == 'N') """
         set -euo pipefail
 
         # ── helpers ──────────────────────────────────────────────────
@@ -130,7 +126,7 @@ process bwa_merged_align {
         if has_reads ${merged_fq}; then
             ${BWA} mem ${indexfiles[0]} ${merged_fq} -t ${cpu} \
                 -R '@RG\\tID:${sample_id}_merged\\tSM:${sample_id}' \
-            | ${SAMTOOLS} view -@ ${cpu} -b ${samtools_flag} - \
+            | ${SAMTOOLS} view -@ ${cpu} -b ${params.samtools_flag} - \
             | ${SAMTOOLS} sort -@ ${cpu} -n -o ${sample_id}_merged_alignment_sorted.bam -
         else
             echo "[INFO] No merged reads for ${sample_id} — creating empty BAM"
@@ -141,14 +137,14 @@ process bwa_merged_align {
         if has_reads ${unmerged_fq}; then
             ${BWA} mem ${indexfiles[0]} ${unmerged_fq} -t ${cpu} \
                 -R '@RG\\tID:${sample_id}_unmerged\\tSM:${sample_id}' \
-            | ${SAMTOOLS} view -@ ${cpu} -b ${samtools_flag} - \
+            | ${SAMTOOLS} view -@ ${cpu} -b ${params.samtools_flag} - \
             | ${SAMTOOLS} sort -@ ${cpu} -n -o ${sample_id}_unmerged_alignment_sorted.bam -
         else
             echo "[INFO] No unmerged reads for ${sample_id} — creating empty BAM"
             empty_bam ${sample_id}_unmerged_alignment_sorted.bam
         fi
     """
-    else if (deduped == 'Y') """
+    else if (${params.deduped} == 'Y') """
         set -euo pipefail
 
         # ── helpers ──────────────────────────────────────────────────
@@ -159,7 +155,7 @@ process bwa_merged_align {
         if has_reads ${merged_fq}; then
             ${BWA} mem ${indexfiles[0]} ${merged_fq} -t ${cpu} \
                 -R '@RG\\tID:${sample_id}_merged\\tSM:${sample_id}' \
-            | ${SAMTOOLS} view -@ ${cpu} -b ${samtools_flag} - \
+            | ${SAMTOOLS} view -@ ${cpu} -b ${params.samtools_flag} - \
             | ${SAMTOOLS} sort -@ ${cpu} -n -o ${sample_id}_merged_alignment_sorted.bam -
 
             ${SAMTOOLS} fixmate -@ ${cpu} -m ${sample_id}_merged_alignment_sorted.bam tmp_merged.bam
@@ -176,7 +172,7 @@ process bwa_merged_align {
         if has_reads ${unmerged_fq}; then
             ${BWA} mem ${indexfiles[0]} ${unmerged_fq} -t ${cpu} \
                 -R '@RG\\tID:${sample_id}_unmerged\\tSM:${sample_id}' \
-            | ${SAMTOOLS} view -@ ${cpu} -b ${samtools_flag} - \
+            | ${SAMTOOLS} view -@ ${cpu} -b ${params.samtools_flag} - \
             | ${SAMTOOLS} sort -@ ${cpu} -n -o ${sample_id}_unmerged_alignment_sorted.bam -
 
             ${SAMTOOLS} fixmate -@ ${cpu} -m ${sample_id}_unmerged_alignment_sorted.bam tmp_unmerged.bam
@@ -190,7 +186,7 @@ process bwa_merged_align {
         fi
     """
     else
-        error "Invalid --deduped flag: ${deduped}. Use Y or N."
+        error "Invalid --deduped flag: ${params.deduped}. Use Y or N."
 }
 
 
@@ -216,7 +212,7 @@ process bwa_align_se {
 
     ${BWA} mem ${indexfiles[0]} ${read} -t ${task.cpus} \
         -R '@RG\\tID:${sample_id}\\tSM:${sample_id}' \
-    | ${SAMTOOLS} view -@ ${task.cpus} -b ${samtools_flag} - \
+    | ${SAMTOOLS} view -@ ${task.cpus} -b ${params.samtools_flag} - \
     | ${SAMTOOLS} sort -@ ${task.cpus} -o ${sample_id}_alignment_sorted.bam -
 
     ${SAMTOOLS} index ${sample_id}_alignment_sorted.bam
@@ -276,14 +272,14 @@ process bwa_rm_contaminant_fq {
     path("${pair_id}.samtools.idxstats"), emit: host_rm_stats
     
     """
-    ${BWA} mem ${indexfiles[0]} ${reads[0]} ${reads[1]} -t ${threads} > ${pair_id}.host.sam
-    ${SAMTOOLS} view -bS ${pair_id}.host.sam | ${SAMTOOLS} sort -@ ${threads} -o ${pair_id}.host.sorted.bam
+    ${BWA} mem ${indexfiles[0]} ${reads[0]} ${reads[1]} -t ${task.cpus} > ${pair_id}.host.sam
+    ${SAMTOOLS} view -bS ${pair_id}.host.sam | ${SAMTOOLS} sort -@ ${task.cpus} -o ${pair_id}.host.sorted.bam
     rm ${pair_id}.host.sam
     ${SAMTOOLS} index ${pair_id}.host.sorted.bam && ${SAMTOOLS} idxstats ${pair_id}.host.sorted.bam > ${pair_id}.samtools.idxstats
     ${SAMTOOLS} view -h -f 12 -b ${pair_id}.host.sorted.bam -o ${pair_id}.host.sorted.removed.bam
-    ${SAMTOOLS} sort -n -@ ${threads} ${pair_id}.host.sorted.removed.bam -o ${pair_id}.host.resorted.removed.bam
+    ${SAMTOOLS} sort -n -@ ${task.cpus} ${pair_id}.host.sorted.removed.bam -o ${pair_id}.host.resorted.removed.bam
     ${SAMTOOLS}  \
-       fastq -@ ${threads} -c 6  \
+       fastq -@ ${task.cpus} -c 6  \
       ${pair_id}.host.resorted.removed.bam \
       -1 ${pair_id}.non.host.R1.fastq.gz \
       -2 ${pair_id}.non.host.R2.fastq.gz \
@@ -330,16 +326,16 @@ process bwa_rm_contaminant_merged_fq {
 
     # ───────────────────────── merged reads ────────────────────────────
     if has_reads ${merged_fq}; then
-        ${BWA} mem ${indexfiles[0]} ${merged_fq} -t ${threads} \\
-            | ${SAMTOOLS} sort -@ ${threads} -o ${sample_id}.merged.host.sorted.bam
+        ${BWA} mem ${indexfiles[0]} ${merged_fq} -t ${task.cpus} \\
+            | ${SAMTOOLS} sort -@ ${task.cpus} -o ${sample_id}.merged.host.sorted.bam
 
         ${SAMTOOLS} index   ${sample_id}.merged.host.sorted.bam
         ${SAMTOOLS} idxstats ${sample_id}.merged.host.sorted.bam \\
             > ${sample_id}.merged.samtools.idxstats
 
         ${SAMTOOLS} view -b -f 4 ${sample_id}.merged.host.sorted.bam \\
-          | ${SAMTOOLS} fastq -@ ${threads} -c 6 - \\
-          | pigz -p ${threads} -c > ${sample_id}.merged.non.host.fastq.gz
+          | ${SAMTOOLS} fastq -@ ${task.cpus} -c 6 - \\
+          | pigz -p ${task.cpus} -c > ${sample_id}.merged.non.host.fastq.gz
     else
         echo "[INFO] No merged reads for ${sample_id} — writing empty outputs"
         echo -n | gzip > ${sample_id}.merged.non.host.fastq.gz
@@ -348,16 +344,16 @@ process bwa_rm_contaminant_merged_fq {
 
     # ──────────────────────── un-merged reads ──────────────────────────
     if has_reads ${unmerged_fq}; then
-        ${BWA} mem ${indexfiles[0]} ${unmerged_fq} -t ${threads} \\
-            | ${SAMTOOLS} sort -@ ${threads} -o ${sample_id}.unmerged.host.sorted.bam
+        ${BWA} mem ${indexfiles[0]} ${unmerged_fq} -t ${task.cpus} \\
+            | ${SAMTOOLS} sort -@ ${task.cpus} -o ${sample_id}.unmerged.host.sorted.bam
 
         ${SAMTOOLS} index   ${sample_id}.unmerged.host.sorted.bam
         ${SAMTOOLS} idxstats ${sample_id}.unmerged.host.sorted.bam \\
             > ${sample_id}.unmerged.samtools.idxstats
 
         ${SAMTOOLS} view -b -f 4 ${sample_id}.unmerged.host.sorted.bam \\
-          | ${SAMTOOLS} fastq -@ ${threads} -c 6 - \\
-          | pigz -p ${threads} -c > ${sample_id}.unmerged.non.host.fastq.gz
+          | ${SAMTOOLS} fastq -@ ${task.cpus} -c 6 - \\
+          | pigz -p ${task.cpus} -c > ${sample_id}.unmerged.non.host.fastq.gz
     else
         echo "[INFO] No unmerged reads for ${sample_id} — writing empty outputs"
         echo -n | gzip > ${sample_id}.unmerged.non.host.fastq.gz

--- a/modules/Alignment/bwa.nf
+++ b/modules/Alignment/bwa.nf
@@ -12,7 +12,7 @@ process index {
 
     script:
     """
-    ${BWA} index ${fasta}
+    \$BWA index ${fasta}
     #--threads $task.cpus 
     """
 }
@@ -40,23 +40,23 @@ process bwa_align {
     script:
     if( params.deduped == "N")
         """
-        ${BWA} mem ${indexfiles[0]} ${reads} -t ${task.cpus} -R '@RG\\tID:${pair_id}\\tSM:${pair_id}' > ${pair_id}_alignment.sam
-        ${SAMTOOLS} view -@ ${task.cpus} -S -b ${params.samtools_flag} ${pair_id}_alignment.sam > ${pair_id}_alignment.bam
+        \$BWA mem ${indexfiles[0]} ${reads} -t ${task.cpus} -R '@RG\\tID:${pair_id}\\tSM:${pair_id}' > ${pair_id}_alignment.sam
+        \$SAMTOOLS view -@ ${task.cpus} -S -b ${params.samtools_flag} ${pair_id}_alignment.sam > ${pair_id}_alignment.bam
         rm ${pair_id}_alignment.sam
-        ${SAMTOOLS} sort -@ ${task.cpus} -n ${pair_id}_alignment.bam -o ${pair_id}_alignment_sorted.bam
+        \$SAMTOOLS sort -@ ${task.cpus} -n ${pair_id}_alignment.bam -o ${pair_id}_alignment_sorted.bam
         rm ${pair_id}_alignment.bam
         """
     else if( params.deduped == "Y")
         """
-        ${BWA} mem ${indexfiles[0]} ${reads} -t ${task.cpus} -R '@RG\\tID:${pair_id}\\tSM:${pair_id}' > ${pair_id}_alignment.sam
-        ${SAMTOOLS} view -@ ${task.cpus} -S -b ${params.samtools_flag} ${pair_id}_alignment.sam > ${pair_id}_alignment.bam
+        \$BWA mem ${indexfiles[0]} ${reads} -t ${task.cpus} -R '@RG\\tID:${pair_id}\\tSM:${pair_id}' > ${pair_id}_alignment.sam
+        \$SAMTOOLS view -@ ${task.cpus} -S -b ${params.samtools_flag} ${pair_id}_alignment.sam > ${pair_id}_alignment.bam
         rm ${pair_id}_alignment.sam
-        ${SAMTOOLS} sort -@ ${task.cpus} -n ${pair_id}_alignment.bam -o ${pair_id}_alignment_sorted.bam
+        \$SAMTOOLS sort -@ ${task.cpus} -n ${pair_id}_alignment.bam -o ${pair_id}_alignment_sorted.bam
         rm ${pair_id}_alignment.bam
-        ${SAMTOOLS} fixmate -@ ${task.cpus} -m ${pair_id}_alignment_sorted.bam ${pair_id}_alignment_sorted_fix.bam
-        ${SAMTOOLS} sort -@ ${task.cpus} ${pair_id}_alignment_sorted_fix.bam -o ${pair_id}_alignment_sorted_fix.sorted.bam
+        \$SAMTOOLS fixmate -@ ${task.cpus} -m ${pair_id}_alignment_sorted.bam ${pair_id}_alignment_sorted_fix.bam
+        \$SAMTOOLS sort -@ ${task.cpus} ${pair_id}_alignment_sorted_fix.bam -o ${pair_id}_alignment_sorted_fix.sorted.bam
         rm ${pair_id}_alignment_sorted_fix.bam
-        ${SAMTOOLS} markdup -r ${pair_id}_alignment_sorted_fix.sorted.bam ${pair_id}_alignment_dedup.bam
+        \$SAMTOOLS markdup -r ${pair_id}_alignment_sorted_fix.sorted.bam ${pair_id}_alignment_dedup.bam
         rm ${pair_id}_alignment_sorted_fix.sorted.bam
         """
     else
@@ -97,14 +97,14 @@ process bwa_merged_align {
 
         # ── helpers ──────────────────────────────────────────────────
         has_reads() { [ "\$(zcat "\$1" 2>/dev/null | head -c 1 | wc -c)" -gt 0 ]; }
-        empty_bam() { printf '@HD\\tVN:1.6\\tSO:unsorted\\n' | ${SAMTOOLS} view -bS -o "\$1" -; }
+        empty_bam() { printf '@HD\\tVN:1.6\\tSO:unsorted\\n' | \$SAMTOOLS view -bS -o "\$1" -; }
 
         # ───── merged reads ──────────────────────────────────────────
         if has_reads ${merged_fq}; then
-            ${BWA} mem ${indexfiles[0]} ${merged_fq} -t ${cpu} \
+            \$BWA mem ${indexfiles[0]} ${merged_fq} -t ${cpu} \
                 -R '@RG\\tID:${sample_id}_merged\\tSM:${sample_id}' \
-            | ${SAMTOOLS} view -@ ${cpu} -b ${params.samtools_flag} - \
-            | ${SAMTOOLS} sort -@ ${cpu} -n -o ${sample_id}_merged_alignment_sorted.bam -
+            | \$SAMTOOLS view -@ ${cpu} -b ${params.samtools_flag} - \
+            | \$SAMTOOLS sort -@ ${cpu} -n -o ${sample_id}_merged_alignment_sorted.bam -
         else
             echo "[INFO] No merged reads for ${sample_id} — creating empty BAM"
             empty_bam ${sample_id}_merged_alignment_sorted.bam
@@ -112,10 +112,10 @@ process bwa_merged_align {
 
         # ───── un-merged reads ───────────────────────────────────────
         if has_reads ${unmerged_fq}; then
-            ${BWA} mem ${indexfiles[0]} ${unmerged_fq} -t ${cpu} \
+            \$BWA mem ${indexfiles[0]} ${unmerged_fq} -t ${cpu} \
                 -R '@RG\\tID:${sample_id}_unmerged\\tSM:${sample_id}' \
-            | ${SAMTOOLS} view -@ ${cpu} -b ${params.samtools_flag} - \
-            | ${SAMTOOLS} sort -@ ${cpu} -n -o ${sample_id}_unmerged_alignment_sorted.bam -
+            | \$SAMTOOLS view -@ ${cpu} -b ${params.samtools_flag} - \
+            | \$SAMTOOLS sort -@ ${cpu} -n -o ${sample_id}_unmerged_alignment_sorted.bam -
         else
             echo "[INFO] No unmerged reads for ${sample_id} — creating empty BAM"
             empty_bam ${sample_id}_unmerged_alignment_sorted.bam
@@ -126,18 +126,18 @@ process bwa_merged_align {
 
         # ── helpers ──────────────────────────────────────────────────
         has_reads() { [ "\$(zcat "\$1" 2>/dev/null | head -c 1 | wc -c)" -gt 0 ]; }
-        empty_bam() { printf '@HD\\tVN:1.6\\tSO:unsorted\\n' | ${SAMTOOLS} view -bS -o "\$1" -; }
+        empty_bam() { printf '@HD\\tVN:1.6\\tSO:unsorted\\n' | \$SAMTOOLS view -bS -o "\$1" -; }
 
         # ───── merged reads (+ dedup) ────────────────────────────────
         if has_reads ${merged_fq}; then
-            ${BWA} mem ${indexfiles[0]} ${merged_fq} -t ${cpu} \
+            \$BWA mem ${indexfiles[0]} ${merged_fq} -t ${cpu} \
                 -R '@RG\\tID:${sample_id}_merged\\tSM:${sample_id}' \
-            | ${SAMTOOLS} view -@ ${cpu} -b ${params.samtools_flag} - \
-            | ${SAMTOOLS} sort -@ ${cpu} -n -o ${sample_id}_merged_alignment_sorted.bam -
+            | \$SAMTOOLS view -@ ${cpu} -b ${params.samtools_flag} - \
+            | \$SAMTOOLS sort -@ ${cpu} -n -o ${sample_id}_merged_alignment_sorted.bam -
 
-            ${SAMTOOLS} fixmate -@ ${cpu} -m ${sample_id}_merged_alignment_sorted.bam tmp_merged.bam
-            ${SAMTOOLS} sort    -@ ${cpu} tmp_merged.bam -o tmp_merged.srt.bam
-            ${SAMTOOLS} markdup -r -@ ${cpu} tmp_merged.srt.bam ${sample_id}_merged_alignment_dedup.bam
+            \$SAMTOOLS fixmate -@ ${cpu} -m ${sample_id}_merged_alignment_sorted.bam tmp_merged.bam
+            \$SAMTOOLS sort    -@ ${cpu} tmp_merged.bam -o tmp_merged.srt.bam
+            \$SAMTOOLS markdup -r -@ ${cpu} tmp_merged.srt.bam ${sample_id}_merged_alignment_dedup.bam
             rm -f tmp_merged.bam tmp_merged.srt.bam
         else
             echo "[INFO] No merged reads for ${sample_id} — creating empty BAMs"
@@ -147,14 +147,14 @@ process bwa_merged_align {
 
         # ───── un-merged reads (+ dedup) ─────────────────────────────
         if has_reads ${unmerged_fq}; then
-            ${BWA} mem ${indexfiles[0]} ${unmerged_fq} -t ${cpu} \
+            \$BWA mem ${indexfiles[0]} ${unmerged_fq} -t ${cpu} \
                 -R '@RG\\tID:${sample_id}_unmerged\\tSM:${sample_id}' \
-            | ${SAMTOOLS} view -@ ${cpu} -b ${params.samtools_flag} - \
-            | ${SAMTOOLS} sort -@ ${cpu} -n -o ${sample_id}_unmerged_alignment_sorted.bam -
+            | \$SAMTOOLS view -@ ${cpu} -b ${params.samtools_flag} - \
+            | \$SAMTOOLS sort -@ ${cpu} -n -o ${sample_id}_unmerged_alignment_sorted.bam -
 
-            ${SAMTOOLS} fixmate -@ ${cpu} -m ${sample_id}_unmerged_alignment_sorted.bam tmp_unmerged.bam
-            ${SAMTOOLS} sort    -@ ${cpu} tmp_unmerged.bam -o tmp_unmerged.srt.bam
-            ${SAMTOOLS} markdup -r -@ ${cpu} tmp_unmerged.srt.bam ${sample_id}_unmerged_alignment_dedup.bam
+            \$SAMTOOLS fixmate -@ ${cpu} -m ${sample_id}_unmerged_alignment_sorted.bam tmp_unmerged.bam
+            \$SAMTOOLS sort    -@ ${cpu} tmp_unmerged.bam -o tmp_unmerged.srt.bam
+            \$SAMTOOLS markdup -r -@ ${cpu} tmp_unmerged.srt.bam ${sample_id}_unmerged_alignment_dedup.bam
             rm -f tmp_unmerged.bam tmp_unmerged.srt.bam
         else
             echo "[INFO] No unmerged reads for ${sample_id} — creating empty BAMs"
@@ -187,12 +187,12 @@ process bwa_align_se {
     """
     set -euo pipefail
 
-    ${BWA} mem ${indexfiles[0]} ${read} -t ${task.cpus} \
+    \$BWA mem ${indexfiles[0]} ${read} -t ${task.cpus} \
         -R '@RG\\tID:${sample_id}\\tSM:${sample_id}' \
-    | ${SAMTOOLS} view -@ ${task.cpus} -b ${params.samtools_flag} - \
-    | ${SAMTOOLS} sort -@ ${task.cpus} -o ${sample_id}_alignment_sorted.bam -
+    | \$SAMTOOLS view -@ ${task.cpus} -b ${params.samtools_flag} - \
+    | \$SAMTOOLS sort -@ ${task.cpus} -o ${sample_id}_alignment_sorted.bam -
 
-    ${SAMTOOLS} index ${sample_id}_alignment_sorted.bam
+    \$SAMTOOLS index ${sample_id}_alignment_sorted.bam
     """
 }
 
@@ -214,12 +214,12 @@ process samtools_dedup_se {
     set -euo pipefail
 
     # ensure coordinate sort (safe to re-sort; markdup requires coord-sorted)
-    ${SAMTOOLS} sort -@ ${task.cpus} -o ${sample_id}.coord.bam ${bam_in}
-    ${SAMTOOLS} index ${sample_id}.coord.bam
+    \$SAMTOOLS sort -@ ${task.cpus} -o ${sample_id}.coord.bam ${bam_in}
+    \$SAMTOOLS index ${sample_id}.coord.bam
 
     # remove duplicates
-    ${SAMTOOLS} markdup -r -@ ${task.cpus} ${sample_id}.coord.bam ${sample_id}_alignment_dedup.bam
-    ${SAMTOOLS} index ${sample_id}_alignment_dedup.bam
+    \$SAMTOOLS markdup -r -@ ${task.cpus} ${sample_id}.coord.bam ${sample_id}_alignment_dedup.bam
+    \$SAMTOOLS index ${sample_id}_alignment_dedup.bam
 
     # clean temp
     rm -f ${sample_id}.coord.bam ${sample_id}.coord.bam.bai
@@ -247,13 +247,13 @@ process bwa_rm_contaminant_fq {
     
     script:
     """
-    ${BWA} mem ${indexfiles[0]} ${reads[0]} ${reads[1]} -t ${task.cpus} > ${pair_id}.host.sam
-    ${SAMTOOLS} view -bS ${pair_id}.host.sam | ${SAMTOOLS} sort -@ ${task.cpus} -o ${pair_id}.host.sorted.bam
+    \$BWA mem ${indexfiles[0]} ${reads[0]} ${reads[1]} -t ${task.cpus} > ${pair_id}.host.sam
+    \$SAMTOOLS view -bS ${pair_id}.host.sam | \$SAMTOOLS sort -@ ${task.cpus} -o ${pair_id}.host.sorted.bam
     rm ${pair_id}.host.sam
-    ${SAMTOOLS} index ${pair_id}.host.sorted.bam && ${SAMTOOLS} idxstats ${pair_id}.host.sorted.bam > ${pair_id}.samtools.idxstats
-    ${SAMTOOLS} view -h -f 12 -b ${pair_id}.host.sorted.bam -o ${pair_id}.host.sorted.removed.bam
-    ${SAMTOOLS} sort -n -@ ${task.cpus} ${pair_id}.host.sorted.removed.bam -o ${pair_id}.host.resorted.removed.bam
-    ${SAMTOOLS}  \
+    \$SAMTOOLS index ${pair_id}.host.sorted.bam && \$SAMTOOLS idxstats ${pair_id}.host.sorted.bam > ${pair_id}.samtools.idxstats
+    \$SAMTOOLS view -h -f 12 -b ${pair_id}.host.sorted.bam -o ${pair_id}.host.sorted.removed.bam
+    \$SAMTOOLS sort -n -@ ${task.cpus} ${pair_id}.host.sorted.removed.bam -o ${pair_id}.host.resorted.removed.bam
+    \$SAMTOOLS  \
        fastq -@ ${task.cpus} -c 6  \
       ${pair_id}.host.resorted.removed.bam \
       -1 ${pair_id}.non.host.R1.fastq.gz \
@@ -298,15 +298,15 @@ process bwa_rm_contaminant_merged_fq {
 
     # ───────────────────────── merged reads ────────────────────────────
     if has_reads ${merged_fq}; then
-        ${BWA} mem ${indexfiles[0]} ${merged_fq} -t ${task.cpus} \\
-            | ${SAMTOOLS} sort -@ ${task.cpus} -o ${sample_id}.merged.host.sorted.bam
+        \$BWA mem ${indexfiles[0]} ${merged_fq} -t ${task.cpus} \\
+            | \$SAMTOOLS sort -@ ${task.cpus} -o ${sample_id}.merged.host.sorted.bam
 
-        ${SAMTOOLS} index   ${sample_id}.merged.host.sorted.bam
-        ${SAMTOOLS} idxstats ${sample_id}.merged.host.sorted.bam \\
+        \$SAMTOOLS index   ${sample_id}.merged.host.sorted.bam
+        \$SAMTOOLS idxstats ${sample_id}.merged.host.sorted.bam \\
             > ${sample_id}.merged.samtools.idxstats
 
-        ${SAMTOOLS} view -b -f 4 ${sample_id}.merged.host.sorted.bam \\
-          | ${SAMTOOLS} fastq -@ ${task.cpus} -c 6 - \\
+        \$SAMTOOLS view -b -f 4 ${sample_id}.merged.host.sorted.bam \\
+          | \$SAMTOOLS fastq -@ ${task.cpus} -c 6 - \\
           | pigz -p ${task.cpus} -c > ${sample_id}.merged.non.host.fastq.gz
     else
         echo "[INFO] No merged reads for ${sample_id} — writing empty outputs"
@@ -316,15 +316,15 @@ process bwa_rm_contaminant_merged_fq {
 
     # ──────────────────────── un-merged reads ──────────────────────────
     if has_reads ${unmerged_fq}; then
-        ${BWA} mem ${indexfiles[0]} ${unmerged_fq} -t ${task.cpus} \\
-            | ${SAMTOOLS} sort -@ ${task.cpus} -o ${sample_id}.unmerged.host.sorted.bam
+        \$BWA mem ${indexfiles[0]} ${unmerged_fq} -t ${task.cpus} \\
+            | \$SAMTOOLS sort -@ ${task.cpus} -o ${sample_id}.unmerged.host.sorted.bam
 
-        ${SAMTOOLS} index   ${sample_id}.unmerged.host.sorted.bam
-        ${SAMTOOLS} idxstats ${sample_id}.unmerged.host.sorted.bam \\
+        \$SAMTOOLS index   ${sample_id}.unmerged.host.sorted.bam
+        \$SAMTOOLS idxstats ${sample_id}.unmerged.host.sorted.bam \\
             > ${sample_id}.unmerged.samtools.idxstats
 
-        ${SAMTOOLS} view -b -f 4 ${sample_id}.unmerged.host.sorted.bam \\
-          | ${SAMTOOLS} fastq -@ ${task.cpus} -c 6 - \\
+        \$SAMTOOLS view -b -f 4 ${sample_id}.unmerged.host.sorted.bam \\
+          | \$SAMTOOLS fastq -@ ${task.cpus} -c 6 - \\
           | pigz -p ${task.cpus} -c > ${sample_id}.unmerged.non.host.fastq.gz
     else
         echo "[INFO] No unmerged reads for ${sample_id} — writing empty outputs"
@@ -354,15 +354,15 @@ process bwa_rm_contaminant_se {
     """
     set -euo pipefail
 
-    ${BWA} mem ${indexfiles[0]} ${read} -t ${task.cpus} \
-      | ${SAMTOOLS} sort -@ ${task.cpus} -o ${sample_id}.host.sorted.bam -
+    \$BWA mem ${indexfiles[0]} ${read} -t ${task.cpus} \
+      | \$SAMTOOLS sort -@ ${task.cpus} -o ${sample_id}.host.sorted.bam -
 
-    ${SAMTOOLS} index ${sample_id}.host.sorted.bam
-    ${SAMTOOLS} idxstats ${sample_id}.host.sorted.bam > ${sample_id}.samtools.idxstats
+    \$SAMTOOLS index ${sample_id}.host.sorted.bam
+    \$SAMTOOLS idxstats ${sample_id}.host.sorted.bam > ${sample_id}.samtools.idxstats
 
     # keep only reads UNMAPPED to host
-    ${SAMTOOLS} view -b -f 4 ${sample_id}.host.sorted.bam \
-      | ${SAMTOOLS} fastq -@ ${task.cpus} -c 6 - \
+    \$SAMTOOLS view -b -f 4 ${sample_id}.host.sorted.bam \
+      | \$SAMTOOLS fastq -@ ${task.cpus} -c 6 - \
       | pigz -p ${task.cpus} -c > ${sample_id}.non.host.fastq.gz
     """
 }
@@ -384,7 +384,7 @@ process HostRemovalStats {
 
     script:
     """
-    ${PYTHON3} $baseDir/bin/samtools_idxstats.py -i ${host_rm_stats} -o host.removal.stats
+    \$PYTHON3 $baseDir/bin/samtools_idxstats.py -i ${host_rm_stats} -o host.removal.stats
     """
 }
 
@@ -408,19 +408,19 @@ process samtools_merge_bams {
     # Count total alignments across all input BAMs
     total=0
     for bam in ${bam_list.join(' ')}; do
-        n=\$(${SAMTOOLS} view -c "\$bam" 2>/dev/null || echo 0)
+        n=\$(\$SAMTOOLS view -c "\$bam" 2>/dev/null || echo 0)
         total=\$((total + n))
     done
 
     if [ "\$total" -gt 0 ]; then
-        ${SAMTOOLS} merge -@ ${cpu} ${sample_id}_combined.unsorted.bam ${bam_list.join(' ')}
-        ${SAMTOOLS} sort  -@ ${cpu} -o ${sample_id}_combined.bam ${sample_id}_combined.unsorted.bam
-        ${SAMTOOLS} index ${sample_id}_combined.bam
+        \$SAMTOOLS merge -@ ${cpu} ${sample_id}_combined.unsorted.bam ${bam_list.join(' ')}
+        \$SAMTOOLS sort  -@ ${cpu} -o ${sample_id}_combined.bam ${sample_id}_combined.unsorted.bam
+        \$SAMTOOLS index ${sample_id}_combined.bam
         rm -f ${sample_id}_combined.unsorted.bam
     else
         echo "[INFO] All input BAMs for ${sample_id} are empty — creating empty combined BAM"
-        printf '@HD\\tVN:1.6\\tSO:coordinate\\n' | ${SAMTOOLS} view -bS -o ${sample_id}_combined.bam -
-        ${SAMTOOLS} index ${sample_id}_combined.bam
+        printf '@HD\\tVN:1.6\\tSO:coordinate\\n' | \$SAMTOOLS view -bS -o ${sample_id}_combined.bam -
+        \$SAMTOOLS index ${sample_id}_combined.bam
     fi
     """
 }

--- a/modules/Alignment/bwa.nf
+++ b/modules/Alignment/bwa.nf
@@ -91,7 +91,7 @@ process bwa_merged_align {
         tuple val(sample_id), path("${sample_id}_unmerged_alignment_dedup.bam"),  emit: unmerged_dedup_bam,  optional: true
 
     script:
-    def cpu = task.cpus ?: threads
+  
     if (params.deduped == 'N') """
         set -euo pipefail
 
@@ -101,10 +101,10 @@ process bwa_merged_align {
 
         # ───── merged reads ──────────────────────────────────────────
         if has_reads ${merged_fq}; then
-            \$BWA mem ${indexfiles[0]} ${merged_fq} -t ${cpu} \
+            \$BWA mem ${indexfiles[0]} ${merged_fq} -t ${task.cpu} \
                 -R '@RG\\tID:${sample_id}_merged\\tSM:${sample_id}' \
-            | \$SAMTOOLS view -@ ${cpu} -b ${params.samtools_flag} - \
-            | \$SAMTOOLS sort -@ ${cpu} -n -o ${sample_id}_merged_alignment_sorted.bam -
+            | \$SAMTOOLS view -@ ${task.cpu} -b ${params.samtools_flag} - \
+            | \$SAMTOOLS sort -@ ${task.cpu} -n -o ${sample_id}_merged_alignment_sorted.bam -
         else
             echo "[INFO] No merged reads for ${sample_id} — creating empty BAM"
             empty_bam ${sample_id}_merged_alignment_sorted.bam
@@ -112,10 +112,10 @@ process bwa_merged_align {
 
         # ───── un-merged reads ───────────────────────────────────────
         if has_reads ${unmerged_fq}; then
-            \$BWA mem ${indexfiles[0]} ${unmerged_fq} -t ${cpu} \
+            \$BWA mem ${indexfiles[0]} ${unmerged_fq} -t ${task.cpu} \
                 -R '@RG\\tID:${sample_id}_unmerged\\tSM:${sample_id}' \
-            | \$SAMTOOLS view -@ ${cpu} -b ${params.samtools_flag} - \
-            | \$SAMTOOLS sort -@ ${cpu} -n -o ${sample_id}_unmerged_alignment_sorted.bam -
+            | \$SAMTOOLS view -@ ${task.cpu} -b ${params.samtools_flag} - \
+            | \$SAMTOOLS sort -@ ${task.cpu} -n -o ${sample_id}_unmerged_alignment_sorted.bam -
         else
             echo "[INFO] No unmerged reads for ${sample_id} — creating empty BAM"
             empty_bam ${sample_id}_unmerged_alignment_sorted.bam
@@ -130,14 +130,14 @@ process bwa_merged_align {
 
         # ───── merged reads (+ dedup) ────────────────────────────────
         if has_reads ${merged_fq}; then
-            \$BWA mem ${indexfiles[0]} ${merged_fq} -t ${cpu} \
+            \$BWA mem ${indexfiles[0]} ${merged_fq} -t ${task.cpu} \
                 -R '@RG\\tID:${sample_id}_merged\\tSM:${sample_id}' \
-            | \$SAMTOOLS view -@ ${cpu} -b ${params.samtools_flag} - \
-            | \$SAMTOOLS sort -@ ${cpu} -n -o ${sample_id}_merged_alignment_sorted.bam -
+            | \$SAMTOOLS view -@ ${task.cpu} -b ${params.samtools_flag} - \
+            | \$SAMTOOLS sort -@ ${task.cpu} -n -o ${sample_id}_merged_alignment_sorted.bam -
 
-            \$SAMTOOLS fixmate -@ ${cpu} -m ${sample_id}_merged_alignment_sorted.bam tmp_merged.bam
-            \$SAMTOOLS sort    -@ ${cpu} tmp_merged.bam -o tmp_merged.srt.bam
-            \$SAMTOOLS markdup -r -@ ${cpu} tmp_merged.srt.bam ${sample_id}_merged_alignment_dedup.bam
+            \$SAMTOOLS fixmate -@ ${task.cpu} -m ${sample_id}_merged_alignment_sorted.bam tmp_merged.bam
+            \$SAMTOOLS sort    -@ ${task.cpu} tmp_merged.bam -o tmp_merged.srt.bam
+            \$SAMTOOLS markdup -r -@ ${task.cpu} tmp_merged.srt.bam ${sample_id}_merged_alignment_dedup.bam
             rm -f tmp_merged.bam tmp_merged.srt.bam
         else
             echo "[INFO] No merged reads for ${sample_id} — creating empty BAMs"
@@ -147,14 +147,14 @@ process bwa_merged_align {
 
         # ───── un-merged reads (+ dedup) ─────────────────────────────
         if has_reads ${unmerged_fq}; then
-            \$BWA mem ${indexfiles[0]} ${unmerged_fq} -t ${cpu} \
+            \$BWA mem ${indexfiles[0]} ${unmerged_fq} -t ${task.cpu} \
                 -R '@RG\\tID:${sample_id}_unmerged\\tSM:${sample_id}' \
-            | \$SAMTOOLS view -@ ${cpu} -b ${params.samtools_flag} - \
-            | \$SAMTOOLS sort -@ ${cpu} -n -o ${sample_id}_unmerged_alignment_sorted.bam -
+            | \$SAMTOOLS view -@ ${task.cpu} -b ${params.samtools_flag} - \
+            | \$SAMTOOLS sort -@ ${task.cpu} -n -o ${sample_id}_unmerged_alignment_sorted.bam -
 
-            \$SAMTOOLS fixmate -@ ${cpu} -m ${sample_id}_unmerged_alignment_sorted.bam tmp_unmerged.bam
-            \$SAMTOOLS sort    -@ ${cpu} tmp_unmerged.bam -o tmp_unmerged.srt.bam
-            \$SAMTOOLS markdup -r -@ ${cpu} tmp_unmerged.srt.bam ${sample_id}_unmerged_alignment_dedup.bam
+            \$SAMTOOLS fixmate -@ ${task.cpu} -m ${sample_id}_unmerged_alignment_sorted.bam tmp_unmerged.bam
+            \$SAMTOOLS sort    -@ ${task.cpu} tmp_unmerged.bam -o tmp_unmerged.srt.bam
+            \$SAMTOOLS markdup -r -@ ${task.cpu} tmp_unmerged.srt.bam ${sample_id}_unmerged_alignment_dedup.bam
             rm -f tmp_unmerged.bam tmp_unmerged.srt.bam
         else
             echo "[INFO] No unmerged reads for ${sample_id} — creating empty BAMs"
@@ -368,7 +368,7 @@ process bwa_rm_contaminant_se {
 }
 
 process HostRemovalStats {
-    tag { sample_id }
+    tag "Summarizing host removal stats"
     label "micro"
 
     publishDir "${params.output}/Results", mode: "copy",
@@ -401,7 +401,7 @@ process samtools_merge_bams {
         tuple val(sample_id), path("${sample_id}_combined.bam"), emit: combo_bam
 
     script:
-    def cpu = task.cpus ?: 4
+
     """
     set -euo pipefail
 
@@ -413,8 +413,8 @@ process samtools_merge_bams {
     done
 
     if [ "\$total" -gt 0 ]; then
-        \$SAMTOOLS merge -@ ${cpu} ${sample_id}_combined.unsorted.bam ${bam_list.join(' ')}
-        \$SAMTOOLS sort  -@ ${cpu} -o ${sample_id}_combined.bam ${sample_id}_combined.unsorted.bam
+        \$SAMTOOLS merge -@ ${task.cpu} ${sample_id}_combined.unsorted.bam ${bam_list.join(' ')}
+        \$SAMTOOLS sort  -@ ${task.cpu} -o ${sample_id}_combined.bam ${sample_id}_combined.unsorted.bam
         \$SAMTOOLS index ${sample_id}_combined.bam
         rm -f ${sample_id}_combined.unsorted.bam
     else

--- a/modules/Alignment/bwa.nf
+++ b/modules/Alignment/bwa.nf
@@ -1,22 +1,9 @@
 include { reference_error ; amr_error ; annotation_error } from './modules/nf-functions.nf'
 
 
-if( params.amr ) {
-    amr = file(params.amr)
-    if( !amr.exists() ) return amr_error(amr)
-}
-if( params.annotation ) {
-    annotation = file(params.annotation)
-    if( !annotation.exists() ) return annotation_error(annotation)
-}
-
-
 process index {
     tag "Creating bwa index"
     label "micro"
-
-    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
-    maxRetries 3
 
     publishDir "${params.output}/Alignment/BWA_Index", mode: "copy"
 
@@ -37,9 +24,6 @@ process index {
 process bwa_align {
     tag "$pair_id"
     label "small"
-
-    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
-    maxRetries 3
 
     publishDir "${params.output}/Alignment/BAM_files", mode: "copy",
         saveAs: { filename ->
@@ -83,12 +67,8 @@ process bwa_align {
 }
 
 process bwa_merged_align {
-
     tag   { sample_id }
     label "small"
-
-    maxRetries 3
-    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
 
     publishDir "${params.output}/Alignment/BAM_files", mode: 'copy',
         saveAs: { fn ->
@@ -253,9 +233,6 @@ process samtools_dedup_se {
 process bwa_rm_contaminant_fq {
     tag { pair_id }
     label "medium"
-
-    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
-    maxRetries 3 
  
     publishDir "${params.output}/HostRemoval", mode: "copy",
         saveAs: { filename ->
@@ -271,6 +248,7 @@ process bwa_rm_contaminant_fq {
     tuple val(pair_id), path("${pair_id}.non.host.R*.fastq.gz"), emit: nonhost_reads
     path("${pair_id}.samtools.idxstats"), emit: host_rm_stats
     
+    script:
     """
     ${BWA} mem ${indexfiles[0]} ${reads[0]} ${reads[1]} -t ${task.cpus} > ${pair_id}.host.sam
     ${SAMTOOLS} view -bS ${pair_id}.host.sam | ${SAMTOOLS} sort -@ ${task.cpus} -o ${pair_id}.host.sorted.bam
@@ -294,9 +272,6 @@ process bwa_rm_contaminant_merged_fq {
 
     tag   { sample_id }
     label "medium"
-
-    maxRetries 3
-    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
 
     publishDir "${params.output}/HostRemoval", mode: 'copy',
         saveAs: { fn ->
@@ -399,9 +374,6 @@ process HostRemovalStats {
     tag { sample_id }
     label "micro"
 
-    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
-    maxRetries 3 
-
     publishDir "${params.output}/Results", mode: "copy",
         saveAs: { filename ->
             if(filename.indexOf(".stats") > 0) "Stats/$filename"
@@ -413,6 +385,7 @@ process HostRemovalStats {
     output:
         path("host.removal.stats"), emit: combo_host_rm_stats
 
+    script:
     """
     ${PYTHON3} $baseDir/bin/samtools_idxstats.py -i ${host_rm_stats} -o host.removal.stats
     """

--- a/modules/Alignment/bwa.nf
+++ b/modules/Alignment/bwa.nf
@@ -101,10 +101,10 @@ process bwa_merged_align {
 
         # ───── merged reads ──────────────────────────────────────────
         if has_reads ${merged_fq}; then
-            \$BWA mem ${indexfiles[0]} ${merged_fq} -t ${task.cpu} \
+            \$BWA mem ${indexfiles[0]} ${merged_fq} -t ${task.cpus} \
                 -R '@RG\\tID:${sample_id}_merged\\tSM:${sample_id}' \
-            | \$SAMTOOLS view -@ ${task.cpu} -b ${params.samtools_flag} - \
-            | \$SAMTOOLS sort -@ ${task.cpu} -n -o ${sample_id}_merged_alignment_sorted.bam -
+            | \$SAMTOOLS view -@ ${task.cpus} -b ${params.samtools_flag} - \
+            | \$SAMTOOLS sort -@ ${task.cpus} -n -o ${sample_id}_merged_alignment_sorted.bam -
         else
             echo "[INFO] No merged reads for ${sample_id} — creating empty BAM"
             empty_bam ${sample_id}_merged_alignment_sorted.bam
@@ -112,10 +112,10 @@ process bwa_merged_align {
 
         # ───── un-merged reads ───────────────────────────────────────
         if has_reads ${unmerged_fq}; then
-            \$BWA mem ${indexfiles[0]} ${unmerged_fq} -t ${task.cpu} \
+            \$BWA mem ${indexfiles[0]} ${unmerged_fq} -t ${task.cpus} \
                 -R '@RG\\tID:${sample_id}_unmerged\\tSM:${sample_id}' \
-            | \$SAMTOOLS view -@ ${task.cpu} -b ${params.samtools_flag} - \
-            | \$SAMTOOLS sort -@ ${task.cpu} -n -o ${sample_id}_unmerged_alignment_sorted.bam -
+            | \$SAMTOOLS view -@ ${task.cpus} -b ${params.samtools_flag} - \
+            | \$SAMTOOLS sort -@ ${task.cpus} -n -o ${sample_id}_unmerged_alignment_sorted.bam -
         else
             echo "[INFO] No unmerged reads for ${sample_id} — creating empty BAM"
             empty_bam ${sample_id}_unmerged_alignment_sorted.bam
@@ -130,14 +130,14 @@ process bwa_merged_align {
 
         # ───── merged reads (+ dedup) ────────────────────────────────
         if has_reads ${merged_fq}; then
-            \$BWA mem ${indexfiles[0]} ${merged_fq} -t ${task.cpu} \
+            \$BWA mem ${indexfiles[0]} ${merged_fq} -t ${task.cpus} \
                 -R '@RG\\tID:${sample_id}_merged\\tSM:${sample_id}' \
-            | \$SAMTOOLS view -@ ${task.cpu} -b ${params.samtools_flag} - \
-            | \$SAMTOOLS sort -@ ${task.cpu} -n -o ${sample_id}_merged_alignment_sorted.bam -
+            | \$SAMTOOLS view -@ ${task.cpus} -b ${params.samtools_flag} - \
+            | \$SAMTOOLS sort -@ ${task.cpus} -n -o ${sample_id}_merged_alignment_sorted.bam -
 
-            \$SAMTOOLS fixmate -@ ${task.cpu} -m ${sample_id}_merged_alignment_sorted.bam tmp_merged.bam
-            \$SAMTOOLS sort    -@ ${task.cpu} tmp_merged.bam -o tmp_merged.srt.bam
-            \$SAMTOOLS markdup -r -@ ${task.cpu} tmp_merged.srt.bam ${sample_id}_merged_alignment_dedup.bam
+            \$SAMTOOLS fixmate -@ ${task.cpus} -m ${sample_id}_merged_alignment_sorted.bam tmp_merged.bam
+            \$SAMTOOLS sort    -@ ${task.cpus} tmp_merged.bam -o tmp_merged.srt.bam
+            \$SAMTOOLS markdup -r -@ ${task.cpus} tmp_merged.srt.bam ${sample_id}_merged_alignment_dedup.bam
             rm -f tmp_merged.bam tmp_merged.srt.bam
         else
             echo "[INFO] No merged reads for ${sample_id} — creating empty BAMs"
@@ -147,14 +147,14 @@ process bwa_merged_align {
 
         # ───── un-merged reads (+ dedup) ─────────────────────────────
         if has_reads ${unmerged_fq}; then
-            \$BWA mem ${indexfiles[0]} ${unmerged_fq} -t ${task.cpu} \
+            \$BWA mem ${indexfiles[0]} ${unmerged_fq} -t ${task.cpus} \
                 -R '@RG\\tID:${sample_id}_unmerged\\tSM:${sample_id}' \
-            | \$SAMTOOLS view -@ ${task.cpu} -b ${params.samtools_flag} - \
-            | \$SAMTOOLS sort -@ ${task.cpu} -n -o ${sample_id}_unmerged_alignment_sorted.bam -
+            | \$SAMTOOLS view -@ ${task.cpus} -b ${params.samtools_flag} - \
+            | \$SAMTOOLS sort -@ ${task.cpus} -n -o ${sample_id}_unmerged_alignment_sorted.bam -
 
-            \$SAMTOOLS fixmate -@ ${task.cpu} -m ${sample_id}_unmerged_alignment_sorted.bam tmp_unmerged.bam
-            \$SAMTOOLS sort    -@ ${task.cpu} tmp_unmerged.bam -o tmp_unmerged.srt.bam
-            \$SAMTOOLS markdup -r -@ ${task.cpu} tmp_unmerged.srt.bam ${sample_id}_unmerged_alignment_dedup.bam
+            \$SAMTOOLS fixmate -@ ${task.cpus} -m ${sample_id}_unmerged_alignment_sorted.bam tmp_unmerged.bam
+            \$SAMTOOLS sort    -@ ${task.cpus} tmp_unmerged.bam -o tmp_unmerged.srt.bam
+            \$SAMTOOLS markdup -r -@ ${task.cpus} tmp_unmerged.srt.bam ${sample_id}_unmerged_alignment_dedup.bam
             rm -f tmp_unmerged.bam tmp_unmerged.srt.bam
         else
             echo "[INFO] No unmerged reads for ${sample_id} — creating empty BAMs"
@@ -391,36 +391,30 @@ process HostRemovalStats {
 process samtools_merge_bams {
     tag { sample_id }
     label 'small'
-
-    publishDir "${params.output}/Alignment/BAM_files/Combined", mode: 'copy'
-
+    publishDir "${params.output}/Alignment/BAM_files/Combined/${subdir}", mode: 'copy'
     input:
         tuple val(sample_id), path(bam_list)
-
+        val(subdir)                          // "" standard, "Deduped" for dedup
     output:
-        tuple val(sample_id), path("${sample_id}_combined.bam"), emit: combo_bam
-
+        tuple val(sample_id), path("${sample_id}_combined*.bam*"), emit: combo_bam
     script:
-
+    def outname = subdir ? "${sample_id}_combined.dedup" : "${sample_id}_combined"
     """
     set -euo pipefail
-
-    # Count total alignments across all input BAMs
     total=0
     for bam in ${bam_list.join(' ')}; do
         n=\$(\$SAMTOOLS view -c "\$bam" 2>/dev/null || echo 0)
         total=\$((total + n))
     done
-
     if [ "\$total" -gt 0 ]; then
-        \$SAMTOOLS merge -@ ${task.cpu} ${sample_id}_combined.unsorted.bam ${bam_list.join(' ')}
-        \$SAMTOOLS sort  -@ ${task.cpu} -o ${sample_id}_combined.bam ${sample_id}_combined.unsorted.bam
-        \$SAMTOOLS index ${sample_id}_combined.bam
-        rm -f ${sample_id}_combined.unsorted.bam
+        \$SAMTOOLS merge -@ ${task.cpus} ${outname}.unsorted.bam ${bam_list.join(' ')}
+        \$SAMTOOLS sort  -@ ${task.cpus} -o ${outname}.bam ${outname}.unsorted.bam
+        \$SAMTOOLS index ${outname}.bam
+        rm -f ${outname}.unsorted.bam
     else
-        echo "[INFO] All input BAMs for ${sample_id} are empty — creating empty combined BAM"
-        printf '@HD\\tVN:1.6\\tSO:coordinate\\n' | \$SAMTOOLS view -bS -o ${sample_id}_combined.bam -
-        \$SAMTOOLS index ${sample_id}_combined.bam
+        echo "[INFO] All input BAMs for ${sample_id} empty — creating empty combined BAM"
+        printf '@HD\\tVN:1.6\\tSO:coordinate\\n' | \$SAMTOOLS view -bS -o ${outname}.bam -
+        \$SAMTOOLS index ${outname}.bam
     fi
     """
 }

--- a/modules/Alignment/bwa.nf
+++ b/modules/Alignment/bwa.nf
@@ -1,6 +1,3 @@
-include { reference_error ; amr_error ; annotation_error } from './modules/nf-functions.nf'
-
-
 process index {
     tag "Creating bwa index"
     label "micro"
@@ -41,7 +38,7 @@ process bwa_align {
         tuple val(pair_id), path("${pair_id}_alignment_dedup.bam"), emit: bwa_dedup_bam, optional: true
 
     script:
-    if( ${params.deduped} == "N")
+    if( params.deduped == "N")
         """
         ${BWA} mem ${indexfiles[0]} ${reads} -t ${task.cpus} -R '@RG\\tID:${pair_id}\\tSM:${pair_id}' > ${pair_id}_alignment.sam
         ${SAMTOOLS} view -@ ${task.cpus} -S -b ${params.samtools_flag} ${pair_id}_alignment.sam > ${pair_id}_alignment.bam
@@ -49,7 +46,7 @@ process bwa_align {
         ${SAMTOOLS} sort -@ ${task.cpus} -n ${pair_id}_alignment.bam -o ${pair_id}_alignment_sorted.bam
         rm ${pair_id}_alignment.bam
         """
-    else if( ${params.deduped} == "Y")
+    else if( params.deduped == "Y")
         """
         ${BWA} mem ${indexfiles[0]} ${reads} -t ${task.cpus} -R '@RG\\tID:${pair_id}\\tSM:${pair_id}' > ${pair_id}_alignment.sam
         ${SAMTOOLS} view -@ ${task.cpus} -S -b ${params.samtools_flag} ${pair_id}_alignment.sam > ${pair_id}_alignment.bam
@@ -95,7 +92,7 @@ process bwa_merged_align {
 
     script:
     def cpu = task.cpus ?: threads
-    if (${params.deduped} == 'N') """
+    if (params.deduped == 'N') """
         set -euo pipefail
 
         # ── helpers ──────────────────────────────────────────────────
@@ -124,7 +121,7 @@ process bwa_merged_align {
             empty_bam ${sample_id}_unmerged_alignment_sorted.bam
         fi
     """
-    else if (${params.deduped} == 'Y') """
+    else if (params.deduped == 'Y') """
         set -euo pipefail
 
         # ── helpers ──────────────────────────────────────────────────

--- a/modules/Alignment/bwa.nf
+++ b/modules/Alignment/bwa.nf
@@ -1,4 +1,4 @@
-include { reference_error ; amr_error ; annotation_error } from "$baseDir/modules/nf-functions.nf"
+include { reference_error ; amr_error ; annotation_error } from './modules/nf-functions.nf'
 
 
 if( params.amr ) {

--- a/modules/Alignment/bwa.nf
+++ b/modules/Alignment/bwa.nf
@@ -391,7 +391,9 @@ process HostRemovalStats {
 process samtools_merge_bams {
     tag { sample_id }
     label 'small'
-    publishDir "${params.output}/Alignment/BAM_files/Combined/${subdir}", mode: 'copy'
+
+    publishDir { "${params.output}/Alignment/BAM_files/Combined/${subdir}" }, mode: 'copy'
+
     input:
         tuple val(sample_id), path(bam_list)
         val(subdir)                          // "" standard, "Deduped" for dedup

--- a/modules/Fastqc/fastqc.nf
+++ b/modules/Fastqc/fastqc.nf
@@ -4,9 +4,6 @@ process fastqc {
     tag "FASTQC on $sample_id"
     label "micro"
 
-    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
-    maxRetries 3
-
     publishDir "${params.output}/QC_analysis/FastQC", mode: 'copy'
 
     input:
@@ -27,9 +24,6 @@ process fastqc {
 process multiqc {
     tag "Running multiQC"
     label "micro"
-
-    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
-    maxRetries 3
     
     publishDir "${params.output}/QC_analysis/", mode: 'copy',
         saveAs: { filename ->

--- a/modules/Fastqc/fastqc.nf
+++ b/modules/Fastqc/fastqc.nf
@@ -16,7 +16,7 @@ process fastqc {
     script:
     """
     mkdir -p ${sample_id}_fastqc_logs
-    fastqc -o ${sample_id}_fastqc_logs -f fastq -q ${reads}
+    \$FASTQC -o ${sample_id}_fastqc_logs -f fastq -q ${reads}
     """
 }
 
@@ -43,7 +43,7 @@ process multiqc {
     script:
     """
     cp $config/* .
-    multiqc -v data* --interactive -f --cl-config "max_table_rows: 5000" --outdir multiqc_data --filename multiqc_report.html
+    \$MULTIQC -v data* --interactive -f --cl-config "max_table_rows: 5000" --outdir multiqc_data --filename multiqc_report.html
     mv multiqc_data/multiqc_report_data/multiqc_general_stats.txt .
     mv multiqc_data/multiqc_report.html .
 

--- a/modules/Microbiome/kraken2.nf
+++ b/modules/Microbiome/kraken2.nf
@@ -189,8 +189,8 @@ process krakenresults {
         path(kraken_reports)
 
     output:
-        path("kraken_analytic_matrix.conf_${kraken_confidence}.csv")
-	path("unclassifieds_kraken_analytic_matrix.conf_${kraken_confidence}.csv")
+        path("kraken_analytic_matrix.conf_${kraken_confidence}.csv"),              emit: kraken_matrix
+        path("unclassifieds_kraken_analytic_matrix.conf_${kraken_confidence}.csv"), emit: kraken_unclassified
 
     """
     ${PYTHON3} $baseDir/bin/kraken2_long_to_wide.py -i ${kraken_reports} -o kraken_analytic_matrix.conf_${kraken_confidence}.csv

--- a/modules/Microbiome/kraken2.nf
+++ b/modules/Microbiome/kraken2.nf
@@ -1,9 +1,3 @@
-params.taxlevel = "S" //level to estimate abundance at [options: D,P,C,O,F,G,S] (default: S)
-params.readlen = 150
-
-threads = params.threads
-kraken_confidence = params.kraken_confidence
-kraken_options = params.kraken_options
 
 process dlkraken {
     tag { "downloading_kraken_db"}
@@ -42,8 +36,8 @@ process runkraken {
 
     publishDir "${params.output}/MicrobiomeAnalysis", mode: 'copy',
         saveAs: { filename ->
-            if(filename.indexOf(".conf_${kraken_confidence}.kraken.raw") > 0) "Kraken/Raw_output_conf_${kraken_confidence}/$filename"
-            else if(filename.indexOf(".conf_${kraken_confidence}.kraken.report") > 0) "Kraken/Report_conf_${kraken_confidence}/$filename"
+            if(filename.indexOf(".conf_${params.kraken_confidence}.kraken.raw") > 0) "Kraken/Raw_output_conf_${params.kraken_confidence}/$filename"
+            else if(filename.indexOf(".conf_${params.kraken_confidence}.kraken.report") > 0) "Kraken/Report_conf_${params.kraken_confidence}/$filename"
             else {}
         }
 
@@ -53,15 +47,15 @@ process runkraken {
 
 
    output:
-      tuple val(sample_id), path("${sample_id}.conf_${kraken_confidence}.kraken.raw"), emit: kraken_raw
-      path("${sample_id}.conf_${kraken_confidence}.kraken.report"), emit: kraken_report
+      tuple val(sample_id), path("${sample_id}.conf_${params.kraken_confidence}.kraken.raw"), emit: kraken_raw
+      path("${sample_id}.conf_${params.kraken_confidence}.kraken.report"), emit: kraken_report
 
     script:
     def opts = (params.kraken_options instanceof List) ? params.kraken_options.join(' ') : (params.kraken_options ?: '')
      """
-     ${KRAKEN2} --db ${krakendb} ${opts} --confidence ${kraken_confidence} --paired ${reads[0]} ${reads[1]} --threads ${threads} --report ${sample_id}.conf_${kraken_confidence}.kraken.report > ${sample_id}.conf_${kraken_confidence}.kraken.raw
+     ${KRAKEN2} --db ${krakendb} ${opts} --confidence ${params.kraken_confidence} --paired ${reads[0]} ${reads[1]} --threads ${task.cpus} --report ${sample_id}.conf_${params.kraken_confidence}.kraken.report > ${sample_id}.conf_${params.kraken_confidence}.kraken.raw
 
-     cut -f 2,3  ${sample_id}.conf_${kraken_confidence}.kraken.raw > ${sample_id}.conf_${kraken_confidence}.kraken.krona
+     cut -f 2,3  ${sample_id}.conf_${params.kraken_confidence}.kraken.raw > ${sample_id}.conf_${params.kraken_confidence}.kraken.krona
     """
 }
 
@@ -112,8 +106,8 @@ process runkraken_merged {
 
     # ── merged reads ───────────────────────────────────────────────
     if has_reads ${merged}; then
-        ${KRAKEN2} --db ${krakendb} ${opts} --confidence ${kraken_confidence} \\
-                   --threads ${threads} \\
+        ${KRAKEN2} --db ${krakendb} ${opts} --confidence ${params.kraken_confidence} \\
+                   --threads ${task.cpus} \\
                    --report ${sample_id}.merged.kraken.report \\
                    ${merged} \\
                    > ${sample_id}.merged.kraken.raw
@@ -124,8 +118,8 @@ process runkraken_merged {
 
     # ── unmerged reads ─────────────────────────────────────────────
     if has_reads ${unmerged}; then
-        ${KRAKEN2} --db ${krakendb} ${opts} --confidence ${kraken_confidence} \\
-                   --threads ${threads} \\
+        ${KRAKEN2} --db ${krakendb} ${opts} --confidence ${params.kraken_confidence} \\
+                   --threads ${task.cpus} \\
                    --report ${sample_id}.unmerged.kraken.report \\
                    ${unmerged} \\
                    > ${sample_id}.unmerged.kraken.raw
@@ -189,36 +183,11 @@ process krakenresults {
         path(kraken_reports)
 
     output:
-        path("kraken_analytic_matrix.conf_${kraken_confidence}.csv"),              emit: kraken_matrix
-        path("unclassifieds_kraken_analytic_matrix.conf_${kraken_confidence}.csv"), emit: kraken_unclassified
+        path("kraken_analytic_matrix.conf_${params.kraken_confidence}.csv"),              emit: kraken_matrix
+        path("unclassifieds_kraken_analytic_matrix.conf_${params.kraken_confidence}.csv"), emit: kraken_unclassified
 
     """
-    ${PYTHON3} $baseDir/bin/kraken2_long_to_wide.py -i ${kraken_reports} -o kraken_analytic_matrix.conf_${kraken_confidence}.csv
+    ${PYTHON3} $baseDir/bin/kraken2_long_to_wide.py -i ${kraken_reports} -o kraken_analytic_matrix.conf_${params.kraken_confidence}.csv
     """
 }
 
-
-process runbracken {
-    label "micro"
-    
-    input:
-       tuple val(sample_id), path(krakenout)
-       tuple val(sample_id), path(krakenout_filtered)
-       path(krakendb)
-
-    """
-    bracken \
-        -d ${krakendb} \
-        -r ${params.readlen} \
-        -i ${krakenout} \
-        -l ${params.taxlevel} \
-        -o ${sample_id}_bracken.tsv
-
-    bracken \
-        -d ${krakendb} \
-        -r ${params.readlen}\
-        -i ${krakenout_filtered} \
-        -l ${params.taxlevel} \
-        -o ${sample_id}_bracken_filtered.tsv
-        """
-}

--- a/modules/Microbiome/kraken2.nf
+++ b/modules/Microbiome/kraken2.nf
@@ -48,7 +48,7 @@ process runkraken {
     script:
     def opts = (params.kraken_options instanceof List) ? params.kraken_options.join(' ') : (params.kraken_options ?: '')
      """
-     ${KRAKEN2} --db ${krakendb} ${opts} --confidence ${params.kraken_confidence} --paired ${reads[0]} ${reads[1]} --threads ${task.cpus} --report ${sample_id}.conf_${params.kraken_confidence}.kraken.report > ${sample_id}.conf_${params.kraken_confidence}.kraken.raw
+     \$KRAKEN2 --db ${krakendb} ${opts} --confidence ${params.kraken_confidence} --paired ${reads[0]} ${reads[1]} --threads ${task.cpus} --report ${sample_id}.conf_${params.kraken_confidence}.kraken.report > ${sample_id}.conf_${params.kraken_confidence}.kraken.raw
 
      cut -f 2,3  ${sample_id}.conf_${params.kraken_confidence}.kraken.raw > ${sample_id}.conf_${params.kraken_confidence}.kraken.krona
     """
@@ -100,7 +100,7 @@ process runkraken_merged {
 
     # ── merged reads ───────────────────────────────────────────────
     if has_reads ${merged}; then
-        ${KRAKEN2} --db ${krakendb} ${opts} --confidence ${params.kraken_confidence} \\
+        \$KRAKEN2 --db ${krakendb} ${opts} --confidence ${params.kraken_confidence} \\
                    --threads ${task.cpus} \\
                    --report ${sample_id}.merged.kraken.report \\
                    ${merged} \\
@@ -112,7 +112,7 @@ process runkraken_merged {
 
     # ── unmerged reads ─────────────────────────────────────────────
     if has_reads ${unmerged}; then
-        ${KRAKEN2} --db ${krakendb} ${opts} --confidence ${params.kraken_confidence} \\
+        \$KRAKEN2 --db ${krakendb} ${opts} --confidence ${params.kraken_confidence} \\
                    --threads ${task.cpus} \\
                    --report ${sample_id}.unmerged.kraken.report \\
                    ${unmerged} \\
@@ -154,7 +154,7 @@ process runkraken_se {
     script:
     def opts = (params.kraken_options instanceof List) ? params.kraken_options.join(' ') : (params.kraken_options ?: '')
     """
-    ${KRAKEN2} --db ${krakendb} ${opts} \
+    \$KRAKEN2 --db ${krakendb} ${opts} \
                --confidence ${params.kraken_confidence} \
                --threads ${task.cpus} \
                --report ${sample_id}.conf_${params.kraken_confidence}.kraken.report \
@@ -178,7 +178,7 @@ process krakenresults {
     
     script:
     """
-    ${PYTHON3} $baseDir/bin/kraken2_long_to_wide.py -i ${kraken_reports} -o kraken_analytic_matrix.conf_${params.kraken_confidence}.csv
+    \$PYTHON3 $baseDir/bin/kraken2_long_to_wide.py -i ${kraken_reports} -o kraken_analytic_matrix.conf_${params.kraken_confidence}.csv
     """
 }
 

--- a/modules/Microbiome/kraken2.nf
+++ b/modules/Microbiome/kraken2.nf
@@ -8,6 +8,7 @@ process dlkraken {
     output:
         path("k2_minusb_20250714/"), emit: kraken_db
 
+    script:
     """
         wget https://genome-idx.s3.amazonaws.com/kraken/k2_minusb_20250714.tar.gz
         mkdir -p k2_minusb_20250714
@@ -174,7 +175,8 @@ process krakenresults {
     output:
         path("kraken_analytic_matrix.conf_${params.kraken_confidence}.csv"),              emit: kraken_matrix
         path("unclassifieds_kraken_analytic_matrix.conf_${params.kraken_confidence}.csv"), emit: kraken_unclassified
-
+    
+    script:
     """
     ${PYTHON3} $baseDir/bin/kraken2_long_to_wide.py -i ${kraken_reports} -o kraken_analytic_matrix.conf_${params.kraken_confidence}.csv
     """

--- a/modules/Microbiome/kraken2.nf
+++ b/modules/Microbiome/kraken2.nf
@@ -3,9 +3,6 @@ process dlkraken {
     tag { "downloading_kraken_db"}
     label "micro"
 
-    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
-    maxRetries 3
-
     publishDir "$baseDir/data/kraken_db/", mode: 'copy'
 
     output:
@@ -30,9 +27,6 @@ process runkraken {
            ? 'large'
            : 'xlarge'
     )
-
-    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
-    maxRetries 3
 
     publishDir "${params.output}/MicrobiomeAnalysis", mode: 'copy',
         saveAs: { filename ->
@@ -60,7 +54,6 @@ process runkraken {
 }
 
 process runkraken_merged {
-
     tag   { sample_id }
     label (
         (
@@ -130,7 +123,6 @@ process runkraken_merged {
     """
 }
 
-
 process runkraken_se {
     tag { sample_id }
     label (
@@ -173,9 +165,6 @@ process runkraken_se {
 process krakenresults {
     tag { }
     label "micro"
-
-    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
-    maxRetries 3
 
     publishDir "${params.output}/Results/", mode: 'copy'
 

--- a/modules/Microbiome/qiime2.nf
+++ b/modules/Microbiome/qiime2.nf
@@ -65,9 +65,6 @@ process Qiime2Filter {
     tag { }
     label "medium"
 
-    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
-    maxRetries 3
-
     publishDir "${params.output}/Qiime2Results", mode: "copy"
 
     input:
@@ -90,9 +87,6 @@ process Qiime2Filter {
 process Qiime2Tree {
     tag { }
     label "medium"
-
-    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
-    maxRetries 3
 
     publishDir "${params.output}/Qiime2Results/Tree", mode: "copy"
 
@@ -117,9 +111,6 @@ process Qiime2Export {
     tag { }
     label "medium"
 
-    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
-    maxRetries 3
-    
     publishDir "${params.output}/Qiime2Results/Exported", mode: "copy"
 
     input:

--- a/modules/Microbiome/qiime2.nf
+++ b/modules/Microbiome/qiime2.nf
@@ -1,9 +1,3 @@
-p_trim_left_f = params.p_trim_left_f
-p_trim_left_r = params.p_trim_left_r
-p_trunc_len_f = params.p_trunc_len_f
-p_trunc_len_r = params.p_trunc_len_r
-
-threads = params.threads
 
 process Qiime2Import {
     tag { }
@@ -47,7 +41,7 @@ process Qiime2Dada2 {
         path("rep-seqs.qza"), emit: rep_seqs
 
     """
-    ${QIIME} dada2 denoise-paired --i-demultiplexed-seqs ${demux} --o-table dada-table.qza --o-representative-sequences rep-seqs.qza --p-trim-left-f ${p_trim_left_f} --p-trim-left-r ${p_trim_left_r} --p-trunc-len-f ${p_trunc_len_f} --p-trunc-len-r ${p_trunc_len_r} --p-n-threads ${threads} --verbose --o-denoising-stats denoise_stats 
+    ${QIIME} dada2 denoise-paired --i-demultiplexed-seqs ${demux} --o-table dada-table.qza --o-representative-sequences rep-seqs.qza --p-trim-left-f ${params.p_trim_left_f} --p-trim-left-r ${params.p_trim_left_r} --p-trunc-len-f ${params.p_trunc_len_f} --p-trunc-len-r ${params.p_trunc_len_r} --p-n-threads ${task.cpus} --verbose --o-denoising-stats denoise_stats 
 
     """
 }

--- a/modules/Microbiome/qiime2.nf
+++ b/modules/Microbiome/qiime2.nf
@@ -12,7 +12,7 @@ process Qiime2Import {
         path("demux.qza"), emit: demux
    script:
     """
-    ${QIIME} tools import \
+    \$QIIME tools import \
       --type 'SampleData[PairedEndSequencesWithQuality]' \
       --input-path ${manifest} \
       --output-path demux.qza \
@@ -35,7 +35,7 @@ process Qiime2Dada2 {
         path("rep-seqs.qza"), emit: rep_seqs
    script:
     """
-    ${QIIME} dada2 denoise-paired --i-demultiplexed-seqs ${demux} --o-table dada-table.qza --o-representative-sequences rep-seqs.qza --p-trim-left-f ${params.p_trim_left_f} --p-trim-left-r ${params.p_trim_left_r} --p-trunc-len-f ${params.p_trunc_len_f} --p-trunc-len-r ${params.p_trunc_len_r} --p-n-threads ${task.cpus} --verbose --o-denoising-stats denoise_stats 
+    \$QIIME dada2 denoise-paired --i-demultiplexed-seqs ${demux} --o-table dada-table.qza --o-representative-sequences rep-seqs.qza --p-trim-left-f ${params.p_trim_left_f} --p-trim-left-r ${params.p_trim_left_r} --p-trunc-len-f ${params.p_trunc_len_f} --p-trunc-len-r ${params.p_trunc_len_r} --p-n-threads ${task.cpus} --verbose --o-denoising-stats denoise_stats 
 
     """
 }
@@ -56,7 +56,7 @@ process Qiime2Classify {
         path("taxonomy.qza"), emit: taxonomy
    script:
     """
-    ${QIIME} feature-classifier classify-sklearn --i-classifier ${database} --i-reads ${rep_seqs} --o-classification taxonomy.qza
+    \$QIIME feature-classifier classify-sklearn --i-classifier ${database} --i-reads ${rep_seqs} --o-classification taxonomy.qza
 
     """
 }
@@ -77,9 +77,9 @@ process Qiime2Filter {
         path("filtered_rep-seqs.qza"), emit: filtered_seqs
    script:
     """
-    ${QIIME} taxa filter-table --i-table ${dada_table} --i-taxonomy ${taxonomy} --p-exclude mitochondria,chloroplast --o-filtered-table filtered_table.qza 
+    \$QIIME taxa filter-table --i-table ${dada_table} --i-taxonomy ${taxonomy} --p-exclude mitochondria,chloroplast --o-filtered-table filtered_table.qza 
 
-    ${QIIME} taxa filter-seqs --i-sequences ${rep_seqs} --i-taxonomy ${taxonomy} --p-exclude mitochondria,chloroplast --o-filtered-sequences filtered_rep-seqs.qza
+    \$QIIME taxa filter-seqs --i-sequences ${rep_seqs} --i-taxonomy ${taxonomy} --p-exclude mitochondria,chloroplast --o-filtered-sequences filtered_rep-seqs.qza
 
     """
 }
@@ -97,13 +97,13 @@ process Qiime2Tree {
         path("rooted-tree.qza"), emit: rooted_tree
    script:        
     """
-    ${QIIME} alignment mafft --i-sequences ${filtered_seqs} --o-alignment aligned-rep-seqs.qza 
+    \$QIIME alignment mafft --i-sequences ${filtered_seqs} --o-alignment aligned-rep-seqs.qza 
     
-    ${QIIME} alignment mask --i-alignment aligned-rep-seqs.qza --o-masked-alignment masked-aligned-rep-seqs.qza 
+    \$QIIME alignment mask --i-alignment aligned-rep-seqs.qza --o-masked-alignment masked-aligned-rep-seqs.qza 
     
-    ${QIIME} phylogeny fasttree --i-alignment masked-aligned-rep-seqs.qza --o-tree unrooted-tree.qza 
+    \$QIIME phylogeny fasttree --i-alignment masked-aligned-rep-seqs.qza --o-tree unrooted-tree.qza 
     
-    ${QIIME} phylogeny midpoint-root --i-tree unrooted-tree.qza --o-rooted-tree rooted-tree.qza 
+    \$QIIME phylogeny midpoint-root --i-tree unrooted-tree.qza --o-rooted-tree rooted-tree.qza 
     """
 }
 
@@ -125,10 +125,10 @@ process Qiime2Export {
         path("dna-sequences.fasta"), emit: dna_seqs
    script:
     """
-    ${QIIME} tools export --input-path filtered_rep-seqs.qza --output-path .
-    ${QIIME} tools export --input-path taxonomy.qza --output-path . 
-    ${QIIME} tools export --input-path rooted-tree.qza --output-path .
-    ${QIIME} tools export --input-path filtered_table.qza --output-path . 
+    \$QIIME tools export --input-path filtered_rep-seqs.qza --output-path .
+    \$QIIME tools export --input-path taxonomy.qza --output-path . 
+    \$QIIME tools export --input-path rooted-tree.qza --output-path .
+    \$QIIME tools export --input-path filtered_table.qza --output-path . 
 
     # Change out column headers in taxonomy file
     sed -i 's/Feature ID/#OTUID/g' taxonomy.tsv

--- a/modules/Microbiome/qiime2.nf
+++ b/modules/Microbiome/qiime2.nf
@@ -3,9 +3,6 @@ process Qiime2Import {
     tag { }
     label "small"
 
-    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
-    maxRetries 3
-
     publishDir "${params.output}/Qiime2Results", mode: "copy"
 
     input:
@@ -28,9 +25,6 @@ process Qiime2Dada2 {
     tag { }
     label "medium"
 
-    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
-    maxRetries 3
-
     publishDir "${params.output}/Qiime2Results", mode: "copy"
 
     input:
@@ -51,9 +45,6 @@ process Qiime2Dada2 {
 process Qiime2Classify {
     tag { }
     label "medium"
-
-    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
-    maxRetries 3
 
     publishDir "${params.output}/Qiime2Results", mode: "copy"
 

--- a/modules/Microbiome/qiime2.nf
+++ b/modules/Microbiome/qiime2.nf
@@ -10,7 +10,7 @@ process Qiime2Import {
 
     output:
         path("demux.qza"), emit: demux
-
+   script:
     """
     ${QIIME} tools import \
       --type 'SampleData[PairedEndSequencesWithQuality]' \
@@ -33,7 +33,7 @@ process Qiime2Dada2 {
     output:
         path("dada-table.qza"), emit: dada_table
         path("rep-seqs.qza"), emit: rep_seqs
-
+   script:
     """
     ${QIIME} dada2 denoise-paired --i-demultiplexed-seqs ${demux} --o-table dada-table.qza --o-representative-sequences rep-seqs.qza --p-trim-left-f ${params.p_trim_left_f} --p-trim-left-r ${params.p_trim_left_r} --p-trunc-len-f ${params.p_trunc_len_f} --p-trunc-len-r ${params.p_trunc_len_r} --p-n-threads ${task.cpus} --verbose --o-denoising-stats denoise_stats 
 
@@ -54,7 +54,7 @@ process Qiime2Classify {
 
     output:
         path("taxonomy.qza"), emit: taxonomy
-
+   script:
     """
     ${QIIME} feature-classifier classify-sklearn --i-classifier ${database} --i-reads ${rep_seqs} --o-classification taxonomy.qza
 
@@ -75,7 +75,7 @@ process Qiime2Filter {
     output:
         path("filtered_table.qza"), emit: filtered_table
         path("filtered_rep-seqs.qza"), emit: filtered_seqs
-
+   script:
     """
     ${QIIME} taxa filter-table --i-table ${dada_table} --i-taxonomy ${taxonomy} --p-exclude mitochondria,chloroplast --o-filtered-table filtered_table.qza 
 
@@ -95,7 +95,7 @@ process Qiime2Tree {
 
     output:
         path("rooted-tree.qza"), emit: rooted_tree
-        
+   script:        
     """
     ${QIIME} alignment mafft --i-sequences ${filtered_seqs} --o-alignment aligned-rep-seqs.qza 
     
@@ -123,7 +123,7 @@ process Qiime2Export {
         path("table-with-taxonomy.biom"), emit: table_taxa
         path("tree.nwk"), emit: tree_nwk
         path("dna-sequences.fasta"), emit: dna_seqs
-
+   script:
     """
     ${QIIME} tools export --input-path filtered_rep-seqs.qza --output-path .
     ${QIIME} tools export --input-path taxonomy.qza --output-path . 

--- a/modules/QC/dedup.nf
+++ b/modules/QC/dedup.nf
@@ -1,0 +1,23 @@
+process DeduplicateReadsSeqkit {
+    tag   { sample_id }
+    label "medium"
+    publishDir "${params.output}/Deduped_reads",
+               mode:'copy', pattern:'*.fastq.gz'
+    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
+    maxRetries 3
+
+    input:
+        tuple val(sample_id), path(input_fq)
+
+    output:
+        tuple val(sample_id), path("${sample_id}.dedup.fastq.gz"), emit: dedup_fq
+        path("${sample_id}.dedupe_seqkit.stats.log"),              emit: dedupe_stats
+
+    script:
+    """
+    seqkit rmdup --threads ${task.cpus} --by-seq \
+        -o ${sample_id}.dedup.fastq.gz \
+        ${input_fq} \
+        > ${sample_id}.dedupe_seqkit.stats.log 2>&1
+    """
+}

--- a/modules/QC/dedup.nf
+++ b/modules/QC/dedup.nf
@@ -1,27 +1,3 @@
-process SE_DeduplicateReadsSeqkit {
-    tag   { sample_id }
-    label "medium"
-    publishDir "${params.output}/Deduped_reads",
-               mode:'copy', pattern:'*.fastq.gz'
-    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
-    maxRetries 3
-
-    input:
-        tuple val(sample_id), path(input_fq)
-
-    output:
-        tuple val(sample_id), path("${sample_id}.dedup.fastq.gz"), emit: dedup_fq
-        path("${sample_id}.dedupe_seqkit.stats.log"),              emit: dedupe_stats
-
-    script:
-    """
-    seqkit rmdup --threads ${task.cpus} --by-seq \
-        -o ${sample_id}.dedup.fastq.gz \
-        ${input_fq} \
-        > ${sample_id}.dedupe_seqkit.stats.log 2>&1
-    """
-}
-
 process PE_DeduplicateReadsSeqkit {
     tag   { sample_id }
     label "medium"
@@ -31,29 +7,31 @@ process PE_DeduplicateReadsSeqkit {
     maxRetries 3
 
     input:
-        tuple val(sample_id), path(r1), path(r2)
+        tuple val(sample_id), path(reads)
 
     output:
         tuple val(sample_id),
-              path("deduped_files/${sample_id}_R1.dedup.fastq.gz"),
-              path("deduped_files/${sample_id}_R2.dedup.fastq.gz"), emit: dedup_pe_fq
-        path("${sample_id}.dedupe_seqkit.stats.log"),               emit: dedupe_stats
+              path("${sample_id}_R1.dedup.fastq.gz"),
+              path("${sample_id}_R2.dedup.fastq.gz"), emit: dedup_pe_fq
+        path("${sample_id}.dedupe_seqkit.stats.log"),  emit: dedupe_stats
 
     script:
     """
-    mkdir -p deduped_files
-
+    # Deduplicate R1
     seqkit rmdup \
-        --threads ${task.cpus} \
-        --by-seq \
-        -1 ${r1} \
-        -2 ${r2} \
-        --out-dir deduped_files \
-        > ${sample_id}.dedupe_seqkit.stats.log 2>&1
+        -j ${task.cpus} \
+        -s \
+        -o ${sample_id}_R1.dedup.fastq.gz \
+        ${reads[0]} \
+        >  ${sample_id}.dedupe_seqkit.stats.log 2>&1
 
-    # seqkit rmdup names outputs after the inputs — rename to convention
-    mv deduped_files/${r1.baseName}.* deduped_files/${sample_id}_R1.dedup.fastq.gz || true
-    mv deduped_files/${r2.baseName}.* deduped_files/${sample_id}_R2.dedup.fastq.gz || true
+    # Deduplicate R2 independently
+    seqkit rmdup \
+        -j ${task.cpus} \
+        -s \
+        -o ${sample_id}_R2.dedup.fastq.gz \
+        ${reads[1]} \
+        >> ${sample_id}.dedupe_seqkit.stats.log 2>&1
     """
 }
 
@@ -67,7 +45,7 @@ process PE_DeduplicateMergedReadsSeqkit {
     maxRetries 3
 
     input:
-        tuple val(sample_id), path(merged_fq), path(unmerged_fq)
+        tuple val(sample_id), path(reads)   // reads[0]=merged, reads[1]=unmerged
 
     output:
         tuple val(sample_id),
@@ -77,20 +55,48 @@ process PE_DeduplicateMergedReadsSeqkit {
 
     script:
     """
-    # Merged reads: fully SE in nature, deduplicate independently
+    # Deduplicate merged reads
     seqkit rmdup \
-        --threads ${task.cpus} \
-        --by-seq \
+        -j ${task.cpus} \
+        -s \
         -o ${sample_id}.merged.dedup.fastq.gz \
-        ${merged_fq} \
+        ${reads[0]} \
         >  ${sample_id}.dedupe_seqkit.stats.log 2>&1
 
-    # Unmerged reads: also SE in nature
+    # Deduplicate unmerged reads
     seqkit rmdup \
-        --threads ${task.cpus} \
-        --by-seq \
+        -j ${task.cpus} \
+        -s \
         -o ${sample_id}.unmerged.dedup.fastq.gz \
-        ${unmerged_fq} \
+        ${reads[1]} \
         >> ${sample_id}.dedupe_seqkit.stats.log 2>&1
+    """
+}
+
+
+process SE_DeduplicateReadsSeqkit {
+    tag   { sample_id }
+    label "medium"
+    publishDir "${params.output}/Deduped_reads",
+               mode: 'copy', pattern: '*.fastq.gz'
+    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
+    maxRetries 3
+
+    input:
+        tuple val(sample_id), path(read)
+
+    output:
+        tuple val(sample_id),
+              path("${sample_id}.dedup.fastq.gz"),     emit: dedup_fq
+        path("${sample_id}.dedupe_seqkit.stats.log"),  emit: dedupe_stats
+
+    script:
+    """
+    seqkit rmdup \
+        -j ${task.cpus} \
+        -s \
+        -o ${sample_id}.dedup.fastq.gz \
+        ${read} \
+        > ${sample_id}.dedupe_seqkit.stats.log 2>&1
     """
 }

--- a/modules/QC/dedup.nf
+++ b/modules/QC/dedup.nf
@@ -57,6 +57,7 @@ process PE_DeduplicateReadsSeqkit {
     """
 }
 
+
 process PE_DeduplicateMergedReadsSeqkit {
     tag   { sample_id }
     label "medium"

--- a/modules/QC/dedup.nf
+++ b/modules/QC/dedup.nf
@@ -1,4 +1,4 @@
-process DeduplicateReadsSeqkit {
+process SE_DeduplicateReadsSeqkit {
     tag   { sample_id }
     label "medium"
     publishDir "${params.output}/Deduped_reads",
@@ -19,5 +19,77 @@ process DeduplicateReadsSeqkit {
         -o ${sample_id}.dedup.fastq.gz \
         ${input_fq} \
         > ${sample_id}.dedupe_seqkit.stats.log 2>&1
+    """
+}
+
+process PE_DeduplicateReadsSeqkit {
+    tag   { sample_id }
+    label "medium"
+    publishDir "${params.output}/Deduped_reads",
+               mode: 'copy', pattern: '*.fastq.gz'
+    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
+    maxRetries 3
+
+    input:
+        tuple val(sample_id), path(r1), path(r2)
+
+    output:
+        tuple val(sample_id),
+              path("deduped_files/${sample_id}_R1.dedup.fastq.gz"),
+              path("deduped_files/${sample_id}_R2.dedup.fastq.gz"), emit: dedup_pe_fq
+        path("${sample_id}.dedupe_seqkit.stats.log"),               emit: dedupe_stats
+
+    script:
+    """
+    mkdir -p deduped_files
+
+    seqkit rmdup \
+        --threads ${task.cpus} \
+        --by-seq \
+        -1 ${r1} \
+        -2 ${r2} \
+        --out-dir deduped_files \
+        > ${sample_id}.dedupe_seqkit.stats.log 2>&1
+
+    # seqkit rmdup names outputs after the inputs — rename to convention
+    mv deduped_files/${r1.baseName}.* deduped_files/${sample_id}_R1.dedup.fastq.gz || true
+    mv deduped_files/${r2.baseName}.* deduped_files/${sample_id}_R2.dedup.fastq.gz || true
+    """
+}
+
+process PE_DeduplicateMergedReadsSeqkit {
+    tag   { sample_id }
+    label "medium"
+    publishDir "${params.output}/Deduped_reads",
+               mode: 'copy', pattern: '*.fastq.gz'
+    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
+    maxRetries 3
+
+    input:
+        tuple val(sample_id), path(merged_fq), path(unmerged_fq)
+
+    output:
+        tuple val(sample_id),
+              path("${sample_id}.merged.dedup.fastq.gz"),
+              path("${sample_id}.unmerged.dedup.fastq.gz"), emit: dedup_merged_fq
+        path("${sample_id}.dedupe_seqkit.stats.log"),        emit: dedupe_stats
+
+    script:
+    """
+    # Merged reads: fully SE in nature, deduplicate independently
+    seqkit rmdup \
+        --threads ${task.cpus} \
+        --by-seq \
+        -o ${sample_id}.merged.dedup.fastq.gz \
+        ${merged_fq} \
+        >  ${sample_id}.dedupe_seqkit.stats.log 2>&1
+
+    # Unmerged reads: also SE in nature
+    seqkit rmdup \
+        --threads ${task.cpus} \
+        --by-seq \
+        -o ${sample_id}.unmerged.dedup.fastq.gz \
+        ${unmerged_fq} \
+        >> ${sample_id}.dedupe_seqkit.stats.log 2>&1
     """
 }

--- a/modules/QC/dedup.nf
+++ b/modules/QC/dedup.nf
@@ -100,3 +100,111 @@ process SE_DeduplicateReadsSeqkit {
         > ${sample_id}.dedupe_seqkit.stats.log 2>&1
     """
 }
+
+process PE_DeduplicateReadsClumpify {
+    tag   { sample_id }
+    label "medium"
+    publishDir "${params.output}/Deduped_reads",
+               mode: 'copy', pattern: '*.fastq.gz'
+    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
+    maxRetries 3
+
+    input:
+        tuple val(sample_id), path(reads)
+
+    output:
+        tuple val(sample_id),
+              path("${sample_id}_R1.dedup.fastq.gz"),
+              path("${sample_id}_R2.dedup.fastq.gz"), emit: dedup_pe_fq
+        path("${sample_id}.dedupe_clumpify.stats.log"), emit: dedupe_stats
+
+    script:
+    // Reserve ~75% of allocated memory for the JVM heap
+    def jvm_mem = (task.memory.toGiga() * 0.75).intValue()
+    """
+    clumpify.sh \
+        -Xmx${jvm_mem}g \
+        threads=${task.cpus} \
+        in1=${reads[0]} \
+        in2=${reads[1]} \
+        out1=${sample_id}_R1.dedup.fastq.gz \
+        out2=${sample_id}_R2.dedup.fastq.gz \
+        dedupe=t \
+        dupesubs=0 \
+        > ${sample_id}.dedupe_clumpify.stats.log 2>&1
+    """
+}
+
+
+process PE_DeduplicateMergedReadsClumpify {
+    tag   { sample_id }
+    label "medium"
+    publishDir "${params.output}/Deduped_reads",
+               mode: 'copy', pattern: '*.fastq.gz'
+    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
+    maxRetries 3
+
+    input:
+        tuple val(sample_id), path(reads)   // reads[0]=merged, reads[1]=unmerged
+
+    output:
+        tuple val(sample_id),
+              path("${sample_id}.merged.dedup.fastq.gz"),
+              path("${sample_id}.unmerged.dedup.fastq.gz"), emit: dedup_merged_fq
+        path("${sample_id}.dedupe_clumpify.stats.log"),      emit: dedupe_stats
+
+    script:
+    def jvm_mem = (task.memory.toGiga() * 0.75).intValue()
+    """
+    # Merged reads: SE-like, deduplicate independently
+    clumpify.sh \
+        -Xmx${jvm_mem}g \
+        threads=${task.cpus} \
+        in=${reads[0]} \
+        out=${sample_id}.merged.dedup.fastq.gz \
+        dedupe=t \
+        dupesubs=0 \
+        >  ${sample_id}.dedupe_clumpify.stats.log 2>&1
+
+    # Unmerged reads: also SE-like, deduplicate independently
+    clumpify.sh \
+        -Xmx${jvm_mem}g \
+        threads=${task.cpus} \
+        in=${reads[1]} \
+        out=${sample_id}.unmerged.dedup.fastq.gz \
+        dedupe=t \
+        dupesubs=0 \
+        >> ${sample_id}.dedupe_clumpify.stats.log 2>&1
+    """
+}
+
+
+process SE_DeduplicateReadsClumpify {
+    tag   { sample_id }
+    label "medium"
+    publishDir "${params.output}/Deduped_reads",
+               mode: 'copy', pattern: '*.fastq.gz'
+    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
+    maxRetries 3
+
+    input:
+        tuple val(sample_id), path(read)
+
+    output:
+        tuple val(sample_id),
+              path("${sample_id}.dedup.fastq.gz"),          emit: dedup_fq
+        path("${sample_id}.dedupe_clumpify.stats.log"),      emit: dedupe_stats
+
+    script:
+    def jvm_mem = (task.memory.toGiga() * 0.75).intValue()
+    """
+    clumpify.sh \
+        -Xmx${jvm_mem}g \
+        threads=${task.cpus} \
+        in=${read} \
+        out=${sample_id}.dedup.fastq.gz \
+        dedupe=t \
+        dupesubs=0 \
+        > ${sample_id}.dedupe_clumpify.stats.log 2>&1
+    """
+}

--- a/modules/QC/dedup.nf
+++ b/modules/QC/dedup.nf
@@ -3,8 +3,6 @@ process PE_DeduplicateReadsSeqkit {
     label "medium"
     publishDir "${params.output}/Deduped_reads",
                mode: 'copy', pattern: '*.fastq.gz'
-    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
-    maxRetries 3
 
     input:
         tuple val(sample_id), path(reads)
@@ -41,8 +39,6 @@ process PE_DeduplicateMergedReadsSeqkit {
     label "medium"
     publishDir "${params.output}/Deduped_reads",
                mode: 'copy', pattern: '*.fastq.gz'
-    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
-    maxRetries 3
 
     input:
         tuple val(sample_id), path(reads)   // reads[0]=merged, reads[1]=unmerged
@@ -79,8 +75,6 @@ process SE_DeduplicateReadsSeqkit {
     label "medium"
     publishDir "${params.output}/Deduped_reads",
                mode: 'copy', pattern: '*.fastq.gz'
-    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
-    maxRetries 3
 
     input:
         tuple val(sample_id), path(read)
@@ -106,8 +100,6 @@ process PE_DeduplicateReadsClumpify {
     label "medium"
     publishDir "${params.output}/Deduped_reads",
                mode: 'copy', pattern: '*.fastq.gz'
-    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
-    maxRetries 3
 
     input:
         tuple val(sample_id), path(reads)
@@ -143,8 +135,6 @@ process PE_DeduplicateMergedReadsClumpify {
     label "medium"
     publishDir "${params.output}/Deduped_reads",
                mode: 'copy', pattern: '*.fastq.gz'
-    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
-    maxRetries 3
 
     input:
         tuple val(sample_id), path(reads)   // reads[0]=merged, reads[1]=unmerged
@@ -189,8 +179,6 @@ process SE_DeduplicateReadsClumpify {
     label "medium"
     publishDir "${params.output}/Deduped_reads",
                mode: 'copy', pattern: '*.fastq.gz'
-    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
-    maxRetries 3
 
     input:
         tuple val(sample_id), path(read)

--- a/modules/QC/dedup.nf
+++ b/modules/QC/dedup.nf
@@ -1,3 +1,5 @@
+clumpify_mem_gb = params.clumpify_mem_gb
+
 process PE_DeduplicateReadsSeqkit {
     tag   { sample_id }
     label "medium"
@@ -119,8 +121,10 @@ process PE_DeduplicateReadsClumpify {
         path("${sample_id}.dedupe_clumpify.stats.log"), emit: dedupe_stats
 
     script:
-    // Reserve ~75% of allocated memory for the JVM heap
-    def jvm_mem = (task.memory.toGiga() * 0.75).intValue()
+    // Reserve ~75% of allocated memory for the JVM heap, use "clumpify_mem_gb" variable 
+    // or default to 8gb
+    def mem_gb = task.memory ? (task.memory.toGiga() * 0.75).intValue() 
+                         : (params.clumpify_mem_gb ?: 8)
     """
     clumpify.sh \
         -Xmx${jvm_mem}g \
@@ -154,7 +158,10 @@ process PE_DeduplicateMergedReadsClumpify {
         path("${sample_id}.dedupe_clumpify.stats.log"),      emit: dedupe_stats
 
     script:
-    def jvm_mem = (task.memory.toGiga() * 0.75).intValue()
+    // Reserve ~75% of allocated memory for the JVM heap, use "clumpify_mem_gb" variable 
+    // or default to 8gb
+    def mem_gb = task.memory ? (task.memory.toGiga() * 0.75).intValue() 
+                         : (params.clumpify_mem_gb ?: 8)
     """
     # Merged reads: SE-like, deduplicate independently
     clumpify.sh \
@@ -196,7 +203,10 @@ process SE_DeduplicateReadsClumpify {
         path("${sample_id}.dedupe_clumpify.stats.log"),      emit: dedupe_stats
 
     script:
-    def jvm_mem = (task.memory.toGiga() * 0.75).intValue()
+    // Reserve ~75% of allocated memory for the JVM heap, use "clumpify_mem_gb" variable 
+    // or default to 8gb
+    def mem_gb = task.memory ? (task.memory.toGiga() * 0.75).intValue() 
+                         : (params.clumpify_mem_gb ?: 8)
     """
     clumpify.sh \
         -Xmx${jvm_mem}g \

--- a/modules/QC/dedup.nf
+++ b/modules/QC/dedup.nf
@@ -123,7 +123,7 @@ process PE_DeduplicateReadsClumpify {
     script:
     // Reserve ~75% of allocated memory for the JVM heap, use "clumpify_mem_gb" variable 
     // or default to 8gb
-    def mem_gb = task.memory ? (task.memory.toGiga() * 0.75).intValue() 
+    def jvm_mem = task.memory ? (task.memory.toGiga() * 0.75).intValue() 
                          : (params.clumpify_mem_gb ?: 8)
     """
     clumpify.sh \
@@ -160,7 +160,7 @@ process PE_DeduplicateMergedReadsClumpify {
     script:
     // Reserve ~75% of allocated memory for the JVM heap, use "clumpify_mem_gb" variable 
     // or default to 8gb
-    def mem_gb = task.memory ? (task.memory.toGiga() * 0.75).intValue() 
+    def jvm_mem = task.memory ? (task.memory.toGiga() * 0.75).intValue() 
                          : (params.clumpify_mem_gb ?: 8)
     """
     # Merged reads: SE-like, deduplicate independently
@@ -205,7 +205,7 @@ process SE_DeduplicateReadsClumpify {
     script:
     // Reserve ~75% of allocated memory for the JVM heap, use "clumpify_mem_gb" variable 
     // or default to 8gb
-    def mem_gb = task.memory ? (task.memory.toGiga() * 0.75).intValue() 
+    def jvm_mem = task.memory ? (task.memory.toGiga() * 0.75).intValue() 
                          : (params.clumpify_mem_gb ?: 8)
     """
     clumpify.sh \

--- a/modules/QC/dedup.nf
+++ b/modules/QC/dedup.nf
@@ -1,5 +1,3 @@
-clumpify_mem_gb = params.clumpify_mem_gb
-
 process PE_DeduplicateReadsSeqkit {
     tag   { sample_id }
     label "medium"

--- a/modules/QC/merge.nf
+++ b/modules/QC/merge.nf
@@ -1,5 +1,3 @@
-threads = params.threads
-
 /*
  * Merge overlapping PE reads with FLASH
  * ------------------------------------------------------------

--- a/modules/QC/merge.nf
+++ b/modules/QC/merge.nf
@@ -10,9 +10,6 @@ process MergeReadsFlash {
     tag   { sample_id }
     label "small"
 
-    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
-    maxRetries 3
-
     publishDir "${params.output}/Flash_reads", mode: 'copy', pattern: '*.fastq.gz',
         saveAs: { fn -> fn }                       // keep original FLASH filenames
 

--- a/modules/QC/merge.nf
+++ b/modules/QC/merge.nf
@@ -22,14 +22,18 @@ process MergeReadsFlash {
         tuple val(sample_id), path(reads)          // reads[0] = R1, reads[1] = R2
 
     output:
-        tuple val(sample_id), path("${sample_id}.extendedFrags.fastq.gz"), emit: merged
-        tuple val(sample_id), path("${sample_id}.notCombined.fastq.gz"),  emit: unmerged
+        tuple val(sample_id), path("${sample_id}.merged.fastq.gz"), emit: merged
+        tuple val(sample_id), path("${sample_id}.unmerged.fastq.gz"),  emit: unmerged
         path("${sample_id}.hist"),                                                    emit: hist
         path("${sample_id}.log"),                                                     emit: flash_log
 
     script:
     """
     flash -M 120 -o ${sample_id} --interleaved-output -z -t ${task.cpus} ${reads[0]} ${reads[1]}  &> ${sample_id}.log
+   
+    # Rename FLASH output files to more intuitive names
+    mv ${sample_id}.extendedFrags.fastq.gz ${sample_id}.merged.fastq.gz
+    mv ${sample_id}.notCombined.fastq.gz ${sample_id}.unmerged.fastq.gz
     """
 }
 

--- a/modules/Resistome/resistome.nf
+++ b/modules/Resistome/resistome.nf
@@ -220,7 +220,7 @@ process plotrarefaction {
 }
 
 
-process runsnp {
+process old_runsnp {
     tag {sample_id}
     label "snp_ignore"
 
@@ -254,7 +254,7 @@ process runsnp {
     """
 }
 
-process dev_runsnp {
+process runsnp {
     tag {sample_id}
     label "snp_ignore"
 

--- a/modules/Resistome/resistome.nf
+++ b/modules/Resistome/resistome.nf
@@ -284,11 +284,11 @@ process runsnp {
         mv ${bam} ${sample_id}.bam
     fi
 
-    python3 SNP_Verification.py -c config.ini -t ${threads} -a true -i ${sample_id}.bam -o ${sample_id}.${prefix}_SNPs --count_matrix ${snp_count_matrix} --detailed_output=all --count_matrix_final ${sample_id}_SNPconfirmed_${prefix}_matrix.csv
+    python3 SNP_Verification.py -c config.ini -t ${threads} -a true -i ${sample_id}.bam -o ${sample_id}.${prefix}_SNPs --count_matrix ${snp_count_matrix} --detailed_output=all
 
     python3 $baseDir/bin/extract_snp_column.py \
       --sample-id "${sample_id}" \
-      --matrix ${sample_id}.${prefix}_SNPs/${sample_id}_SNPconfirmed_${prefix}_matrix.csv \
+      --matrix ${sample_id}.${prefix}_SNPs/"${sample_id}.${prefix}_SNPs${snp_count_matrix}" \
       --out-tsv "${sample_id}.SNP_confirmed_gene.tsv"
     """
 }

--- a/modules/Resistome/resistome.nf
+++ b/modules/Resistome/resistome.nf
@@ -52,8 +52,10 @@ process build_dependencies {
     #rm -rf resistomeanalyzer
     cp $baseDir/bin/resistome .
 
-    git clone https://github.com/Isabella136/AmrPlusPlus_SNP.git
+    #git clone https://github.com/Isabella136/AmrPlusPlus_SNP.git
+    git clone https://github.com/EnriqueDoster/AmrPlusPlus_SNP.git
     chmod -R 777 AmrPlusPlus_SNP/
+    cd AmrPlusPlus_SNP
     """
 
 

--- a/modules/Resistome/resistome.nf
+++ b/modules/Resistome/resistome.nf
@@ -284,11 +284,11 @@ process runsnp {
         mv ${bam} ${sample_id}.bam
     fi
 
-    python3 SNP_Verification.py -c config.ini -t ${threads} -a true -i ${sample_id}.bam -o ${sample_id}.${prefix}_SNPs --count_matrix ${snp_count_matrix} --detailed_output=all
+    python3 SNP_Verification.py -c config.ini -t ${threads} -a true -i ${sample_id}.bam -o ${sample_id}.${prefix}_SNPs --count_matrix ${snp_count_matrix} --detailed_output=all --count_matrix_final ${sample_id}_SNPconfirmed_${prefix}_matrix.csv
 
     python3 $baseDir/bin/extract_snp_column.py \
       --sample-id "${sample_id}" \
-      --matrix ${sample_id}.${prefix}_SNPs/"${sample_id}.${prefix}_SNPs${snp_count_matrix}" \
+      --matrix ${sample_id}.${prefix}_SNPs/${sample_id}_SNPconfirmed_${prefix}_matrix.csv \
       --out-tsv "${sample_id}.SNP_confirmed_gene.tsv"
     """
 }

--- a/modules/Resistome/resistome.nf
+++ b/modules/Resistome/resistome.nf
@@ -68,7 +68,7 @@ process runresistome {
     set -euo pipefail
 
     # Check if BAM has any alignments
-    aln_count=(\$SAMTOOLS view -c ${bam} 2>/dev/null || echo 0)
+    aln_count=\$(\$SAMTOOLS view -c ${bam} 2>/dev/null || echo 0)
 
     if [ "\$aln_count" -gt 0 ]; then
         \$SAMTOOLS view -h ${bam} > ${sample_id}.sam
@@ -135,7 +135,7 @@ process runrarefaction {
     """
     set -euo pipefail
 
-    aln_count=(\$SAMTOOLS view -c ${bam} 2>/dev/null || echo 0)
+    aln_count=\$(\$SAMTOOLS view -c ${bam} 2>/dev/null || echo 0)
 
     if [ "\$aln_count" -gt 0 ]; then
         \$SAMTOOLS view -h ${bam} > ${sample_id}.sam

--- a/modules/Resistome/resistome.nf
+++ b/modules/Resistome/resistome.nf
@@ -93,6 +93,134 @@ process runresistome {
     """
 }
 
+
+process runresistome_analyzer {
+    tag { sample_id }
+    label "medium"
+
+    publishDir "${params.output}/ResistomeAnalysis", mode: "copy",
+        saveAs: { filename ->
+            if      (filename.endsWith(".gene.tsv"))            "ResistomeCounts/$filename"
+            else if (filename.endsWith("_per_read.tsv"))        "PerReadInfo/$filename"
+            else if (filename.endsWith("_coverage_stats.tsv"))  "CoverageStats/$filename"
+            else {}
+        }
+
+    input:
+        tuple val(sample_id), path(bam)
+
+    output:
+        tuple val(sample_id), path("${sample_id}*.tsv"),    emit: resistome_tsv
+        path("${sample_id}.${params.prefix}.gene.tsv"),      emit: resistome_counts
+
+    script:
+    def count_mode = params.count_mode ?: "fragment"
+    def group_flag = (params.group_aware == "N")     ? "--no-group-aware"     : "--group-aware"
+    def edge_flag  = (params.edge_aware_qcov == "N")  ? "--no-edge-aware-qcov" : "--edge-aware-qcov"
+    def supp_flag  = (params.include_supplementary == "Y") ? "--include-supplementary" : ""
+    def cigar_flag = (params.cigar_aware_coverage  == "Y") ? "--cigar-aware-coverage"  : ""
+    """
+    set -euo pipefail
+
+    aln_count=\$(\$SAMTOOLS view -c ${bam} 2>/dev/null || echo 0)
+
+    if [ "\$aln_count" -gt 0 ]; then
+        \$PYTHON3 $baseDir/bin/alignment_analyzer.py \\
+            -i ${bam} \\
+            -r ${sample_id}.${params.prefix}_per_read.tsv \\
+            -g ${sample_id}.${params.prefix}.gene_summary.tsv \\
+            --sample-id ${sample_id} \\
+            --count-mode ${count_mode} \\
+            --min-mapq ${params.min_mapq} \\
+            --min-gene-fraction ${params.min_gene_fraction} \\
+            --min-query-coverage ${params.min_query_coverage} \\
+            --coverage-output ${sample_id}.${params.prefix}_coverage_stats.tsv \\
+            ${group_flag} ${edge_flag} ${supp_flag} ${cigar_flag}
+
+        # Reshape: gene_accession \\t meg_id \\t count  ->  sample \\t gene \\t count
+        tail -n +2 ${sample_id}.${params.prefix}.gene_summary.tsv \\
+          | awk -v s="${sample_id}" 'BEGIN{FS=OFS="\\t"} {print s, \$1, \$3}' \\
+          > ${sample_id}.${params.prefix}.gene.tsv
+    else
+        echo "[INFO] No alignments in BAM for ${sample_id} — writing empty gene counts"
+        : > ${sample_id}.${params.prefix}.gene.tsv
+    fi
+    """
+}
+
+// Coverage-threshold sweep diagnostic. Runs coverage_threshold_sweep.py on each BAM
+// to profile how gene detection drops off as coverage/quality thresholds increase,
+// then summarizes all per-sample sweeps with plot_sweep_dropoff.R.
+//
+// NOTE on counting: coverage_threshold_sweep.py counts per-FRAGMENT (mates resolved
+// together via base_read_id), so paired-end (unmerged) and FLASH-merged reads are
+// weighted identically. This matches --count-mode fragment in alignment_analyzer.py.
+
+process coverage_threshold_sweep {
+    tag { prefix }
+    label "medium"
+    publishDir "${params.output}/CoverageSweep/PerSample", mode: "copy"
+
+    input:
+        tuple val(prefix), path(bam)
+
+    output:
+        // All four are emitted into one channel so the combine step can stage them
+        // together. gene_detail + length_quantiles are what plot_sweep_dropoff.R needs;
+        // _results.csv is the main grid; _redundancy.csv is optional diagnostics.
+        path("${prefix}_*.csv"), emit: sweep_csvs
+
+    script:
+    def group_flag = (params.group_aware == "N")          ? "--no-group-aware"     : "--group-aware"
+    def edge_flag  = (params.sweep_edge_aware_qcov == "N") ? "--no-edge-aware-qcov" : "--edge-aware-qcov"
+    def snp_flag   = (params.sweep_exclude_snp == "Y")     ? "--exclude-snp-confirmation" : ""
+    """
+    set -euo pipefail
+
+    aln_count=\$(\$SAMTOOLS view -c ${bam} 2>/dev/null || echo 0)
+
+    if [ "\$aln_count" -gt 0 ]; then
+        \$PYTHON3 $baseDir/bin/coverage_threshold_sweep.py \\
+            -i ${bam} \\
+            -o ${prefix}_results.csv \\
+            --min-mapq ${params.min_mapq} \\
+            --gene-detail-output ${prefix}_gene_detail.csv \\
+            --redundancy-output ${prefix}_redundancy.csv \\
+            --length-quantiles-output ${prefix}_length_quantiles.csv \\
+            ${group_flag} ${edge_flag} ${snp_flag}
+    else
+        echo "[INFO] No alignments in ${bam} — writing empty sweep CSVs"
+        echo "min_query_coverage,min_identity,min_match_qcov,min_gene_fraction,n_alignments_retained" \\
+            > ${prefix}_results.csv
+        echo "min_query_coverage,gene_accession,gene_fraction,read_count" > ${prefix}_gene_detail.csv
+        echo "min_query_coverage,group,n_accessions" > ${prefix}_redundancy.csv
+        echo "min_query_coverage,n_alignments" > ${prefix}_length_quantiles.csv
+    fi
+    """
+}
+
+process plot_sweep_dropoff {
+    tag "sweep_summary"
+    label "small"
+    publishDir "${params.output}/CoverageSweep/Summary", mode: "copy"
+
+    input:
+        path(sweep_csvs)
+
+    output:
+        path("*.pdf"), optional: true
+        path("*.png"), optional: true
+        path("*.tsv"), optional: true
+        path("*.csv"), optional: true
+
+    script:
+    """
+    set -euo pipefail
+    \$RSCRIPT $baseDir/bin/plot_sweep_dropoff.R ${sweep_csvs.join(' ')}
+    """
+}
+
+
 process resistomeresults {
     tag "Make AMR count matrix"
     label "small"

--- a/modules/Resistome/resistome.nf
+++ b/modules/Resistome/resistome.nf
@@ -199,26 +199,51 @@ process coverage_threshold_sweep {
     """
 }
 
+process combine_sweep_results {
+    tag "combine_sweep"
+    label "small"
+    publishDir "${params.output}/CoverageSweep/Combined", mode: "copy"
+
+    input:
+        // every per-sample CSV, staged flat into the task workdir
+        path(all_csvs)
+
+    output:
+        path("combined/combined_*.csv"), emit: combined
+
+    script:
+    """
+    set -euo pipefail
+    # combine_sweep_results.py scans a directory for the per-sample sweep CSVs and
+    # injects a sample_id column (the BAM basename) into each row. All staged CSVs
+    # are already in the task workdir ('.'), so scan that directly.
+    \$PYTHON3 $baseDir/bin/combine_sweep_results.py . --out-dir combined
+    """
+}
+
 process plot_sweep_dropoff {
     tag "sweep_summary"
     label "small"
     publishDir "${params.output}/CoverageSweep/Summary", mode: "copy"
 
     input:
-        path(sweep_csvs)
+        path(combined_dir_csvs)   // the combined_*.csv files
 
     output:
-        path("*.pdf"), optional: true
-        path("*.png"), optional: true
-        path("*.tsv"), optional: true
-        path("*.csv"), optional: true
+        path("figures/*"), optional: true
+        path("*.png"),     optional: true
+        path("*.csv"),     optional: true
 
     script:
     """
     set -euo pipefail
-    \$RSCRIPT $baseDir/bin/plot_sweep_dropoff.R ${sweep_csvs.join(' ')}
+    # plot_sweep_dropoff.R reads combined_gene_detail.csv / combined_results.csv /
+    # combined_length_quantiles.csv from its input directory ('.') and writes to
+    # ./figures by default.
+    \$RSCRIPT $baseDir/bin/plot_sweep_dropoff.R . figures
     """
 }
+
 
 
 process resistomeresults {
@@ -360,8 +385,10 @@ process runsnp {
 
     publishDir "${params.output}/ResistomeAnalysis/SNP_verification", mode: "copy",
             saveAs: { filename ->
-                if(filename.indexOf(".tsv") > 0) "SNP_verification_counts/$filename"
-                else "SNP_detailed_output/$filename"
+                if(filename.indexOf(".tsv") > 0)                       "SNP_verification_counts/$filename"
+                else if(filename.indexOf("snp_coverage_stats") > 0)    "SNP_coverage_stats/$filename"
+                else if(filename.indexOf("snp_verification_summary") > 0) "SNP_summary/$filename"
+                else                                                   "SNP_detailed_output/$filename"
             }
 
     input:
@@ -370,24 +397,46 @@ process runsnp {
 
     output:
         path("${sample_id}.SNP_confirmed_gene.tsv"), emit: snp_counts
-        path("${sample_id}.${params.prefix}_SNPs/${sample_id}/${sample_id}.${params.prefix}_SNPs_SNPs_resistant_reads.txt") , optional: true
-        path("${sample_id}.${params.prefix}_SNPs/${sample_id}/${sample_id}.${params.prefix}_SNPs_snp_coverage_stats.csv")
-        path("${sample_id}.${params.prefix}_SNPs/${sample_id}/${sample_id}.${params.prefix}_SNPs_snp_verification_summary.csv")
+        path("${sample_id}.${params.prefix}_SNPs_snp_coverage_stats.csv"),       optional: true, emit: coverage_stats
+        path("${sample_id}.${params.prefix}_SNPs_snp_verification_summary.csv"), optional: true, emit: summary
+        path("${sample_id}.${params.prefix}_SNPs_resistant_reads.csv"),          optional: true
+
     script:
     """
     cp -rsa $baseDir/bin/AmrPlusPlus_SNP/* .
 
-    # change name to stay consistent with count matrix name, but only if the names don't match
+    # Rename BAM to a clean, dot-free stem so the tool's sample subfolder is predictable.
     if [ "${bam}" != "${sample_id}.bam" ]; then
         mv ${bam} ${sample_id}.bam
     fi
 
-    \$PYTHON3 SNP_Verification.py -c config.ini -t ${task.cpus} -a true -i ${sample_id}.bam -o ${sample_id}.${params.prefix}_SNPs --count_matrix ${snp_count_matrix} --detailed_output=all
+    \$PYTHON3 SNP_Verification.py -c config.ini -t ${task.cpus} -a true \\
+        -i ${sample_id}.bam -o ${sample_id}.${params.prefix}_SNPs \\
+        --count_matrix ${snp_count_matrix} --detailed_output=all
 
-    \$PYTHON3 $baseDir/bin/extract_snp_column.py \
-      --sample-id "${sample_id}" \
-      --matrix ${sample_id}.${params.prefix}_SNPs/"${sample_id}.${params.prefix}_SNPs_${snp_count_matrix}" \
+    # The tool derives its sample subfolder from the FIRST dot-token of the bam name.
+    # Since we renamed the bam to ${sample_id}.bam, that token is everything before the
+    # first '.' in "${sample_id}". Compute it so paths are correct even if sample_id has dots.
+    SNP_SUBDIR=\$(echo "${sample_id}" | cut -d. -f1)
+    SNP_OUT="${sample_id}.${params.prefix}_SNPs"
+
+    # Confirmed matrix -> per-sample confirmed-gene TSV
+    \$PYTHON3 $baseDir/bin/extract_snp_column.py \\
+      --sample-id "${sample_id}" \\
+      --matrix "\${SNP_OUT}/\${SNP_OUT}_${snp_count_matrix}" \\
       --out-tsv "${sample_id}.SNP_confirmed_gene.tsv"
+
+    # Surface the coverage-stats + summary CSVs into the task workdir so publishDir
+    # (and the optional emits above) can capture them by their flat names.
+    if [ -f "\${SNP_OUT}/\${SNP_SUBDIR}/\${SNP_OUT}_snp_coverage_stats.csv" ]; then
+        cp "\${SNP_OUT}/\${SNP_SUBDIR}/\${SNP_OUT}_snp_coverage_stats.csv" .
+    fi
+    if [ -f "\${SNP_OUT}/\${SNP_SUBDIR}/\${SNP_OUT}_snp_verification_summary.csv" ]; then
+        cp "\${SNP_OUT}/\${SNP_SUBDIR}/\${SNP_OUT}_snp_verification_summary.csv" .
+    fi
+    if [ -f "\${SNP_OUT}/\${SNP_SUBDIR}/\${SNP_OUT}_resistant_reads.csv" ]; then
+        cp "\${SNP_OUT}/\${SNP_SUBDIR}/\${SNP_OUT}_resistant_reads.csv" .
+    fi
     """
 }
 
@@ -411,3 +460,35 @@ process snpresults {
 }
 
 
+process snp_coverage_summary {
+    tag "Combine SNP coverage stats"
+    label "micro"
+
+    publishDir "${params.output}/Results", mode: "copy"
+
+    input:
+        path(coverage_csvs)
+        val  prefix
+
+    output:
+        path("SNP_coverage_stats_${prefix}.csv"), emit: coverage_summary
+
+    script:
+    """
+    set -euo pipefail
+    out="SNP_coverage_stats_${prefix}.csv"
+    first=1
+    for f in ${coverage_csvs}; do
+        [ -s "\$f" ] || continue
+        if [ \$first -eq 1 ]; then
+            head -1 "\$f" > "\$out"
+            first=0
+        fi
+        tail -n +2 "\$f" >> "\$out"
+    done
+    # Guarantee the output exists even if no sample produced coverage stats
+    if [ \$first -eq 1 ]; then
+        echo "sample_name,gene_name,gene_type,original_amrplusplus_count,total_reads_analyzed,reads_covering_snp_position,reads_with_snp_confirmed,percentage,original_code_would_set,new_count_percentage_based,snp_confirmed" > "\$out"
+    fi
+    """
+}

--- a/modules/Resistome/resistome.nf
+++ b/modules/Resistome/resistome.nf
@@ -5,17 +5,6 @@ if( params.annotation ) {
     if( !annotation.exists() ) return annotation_error(annotation)
 }
 
-threshold = params.threshold
-threads = params.threads
-
-
-min = params.min
-max = params.max
-skip = params.skip
-samples = params.samples
-
-deduped = params.deduped
-prefix = params.prefix
 
 process build_dependencies {
     tag "Download SNP dependencies"
@@ -83,7 +72,7 @@ process runresistome {
 
     output:
         tuple val(sample_id), path("${sample_id}*.tsv"), emit: resistome_tsv
-        path("${sample_id}.${prefix}.gene.tsv"), emit: resistome_counts
+        path("${sample_id}.${params.prefix}.gene.tsv"), emit: resistome_counts
 
     script:
     """
@@ -98,18 +87,18 @@ process runresistome {
         $resistome -ref_fp ${amr} \\
           -annot_fp ${annotation} \\
           -sam_fp ${sample_id}.sam \\
-          -gene_fp ${sample_id}.${prefix}.gene.tsv \\
-          -group_fp ${sample_id}.${prefix}.group.tsv \\
-          -mech_fp ${sample_id}.${prefix}.mechanism.tsv \\
-          -class_fp ${sample_id}.${prefix}.class.tsv \\
-          -type_fp ${sample_id}.${prefix}.type.tsv \\
-          -t ${threshold}
+          -gene_fp ${sample_id}.${params.prefix}.gene.tsv \\
+          -group_fp ${sample_id}.${params.prefix}.group.tsv \\
+          -mech_fp ${sample_id}.${params.prefix}.mechanism.tsv \\
+          -class_fp ${sample_id}.${params.prefix}.class.tsv \\
+          -type_fp ${sample_id}.${params.prefix}.type.tsv \\
+          -t ${params.threshold}
 
         rm ${sample_id}.sam
     else
         echo "[INFO] No alignments in BAM for ${sample_id} — writing empty resistome counts"
         for level in gene group mechanism class type; do
-            printf "Header\\t0\\n" > ${sample_id}.${prefix}.\${level}.tsv
+            printf "Header\\t0\\n" > ${sample_id}.${params.prefix}.\${level}.tsv
         done
     fi
     """
@@ -129,11 +118,11 @@ process resistomeresults {
         val  prefix
 
     output:
-        path("${prefix}_analytic_matrix.csv"), emit: raw_count_matrix
-        path("${prefix}_analytic_matrix.csv"), emit: snp_count_matrix, optional: true
+        path("${params.prefix}_analytic_matrix.csv"), emit: raw_count_matrix
+        path("${params.prefix}_analytic_matrix.csv"), emit: snp_count_matrix, optional: true
 
     """
-    ${PYTHON3} $baseDir/bin/amr_long_to_wide.py -i ${resistomes} -o ${prefix}_analytic_matrix.csv
+    ${PYTHON3} $baseDir/bin/amr_long_to_wide.py -i ${resistomes} -o ${params.prefix}_analytic_matrix.csv
     """
 }
 
@@ -177,11 +166,11 @@ process runrarefaction {
           -mech_fp ${sample_id}.mech.tsv \\
           -class_fp ${sample_id}.class.tsv \\
           -type_fp ${sample_id}.type.tsv \\
-          -min ${min} \\
-          -max ${max} \\
-          -skip ${skip} \\
-          -samples ${samples} \\
-          -t ${threshold}
+          -min ${params.min} \\
+          -max ${params.max} \\
+          -skip ${params.skip} \\
+          -samples ${params.samples} \\
+          -t ${params.threshold}
 
         rm ${sample_id}.sam
     else
@@ -247,11 +236,11 @@ process old_runsnp {
         mv ${bam} ${sample_id}.bam
     fi
 
-    python3 SNP_Verification.py -c config.ini -t ${threads} -a true -i ${sample_id}.bam -o ${sample_id}.${prefix}_SNPs --count_matrix ${snp_count_matrix} --detailed_output=all
+    python3 SNP_Verification.py -c config.ini -t ${task.cpus} -a true -i ${sample_id}.bam -o ${sample_id}.${prefix}_SNPs --count_matrix ${snp_count_matrix} --detailed_output=all
 
     python3 $baseDir/bin/extract_snp_column.py \
       --sample-id "${sample_id}" \
-      --matrix "${sample_id}.${prefix}_SNPs${snp_count_matrix}" \
+      --matrix "${sample_id}.${params.prefix}_SNPs${snp_count_matrix}" \
       --out-tsv "${sample_id}.SNP_confirmed_gene.tsv"
     """
 }
@@ -272,9 +261,9 @@ process runsnp {
 
     output:
         path("${sample_id}.SNP_confirmed_gene.tsv"), emit: snp_counts
-        path("${sample_id}.${prefix}_SNPs/${sample_id}/${sample_id}.${prefix}_SNPs_SNPs_resistant_reads.txt") , optional: true
-        path("${sample_id}.${prefix}_SNPs/${sample_id}/${sample_id}.${prefix}_SNPs_snp_coverage_stats.csv")
-        path("${sample_id}.${prefix}_SNPs/${sample_id}/${sample_id}.${prefix}_SNPs_snp_verification_summary.csv")
+        path("${sample_id}.${prefix}_SNPs/${sample_id}/${sample_id}.${params.prefix}_SNPs_SNPs_resistant_reads.txt") , optional: true
+        path("${sample_id}.${prefix}_SNPs/${sample_id}/${sample_id}.${params.prefix}_SNPs_snp_coverage_stats.csv")
+        path("${sample_id}.${prefix}_SNPs/${sample_id}/${sample_id}.${params.prefix}_SNPs_snp_verification_summary.csv")
 
     """
     cp -rsa $baseDir/bin/AmrPlusPlus_SNP/* .
@@ -284,11 +273,11 @@ process runsnp {
         mv ${bam} ${sample_id}.bam
     fi
 
-    python3 SNP_Verification.py -c config.ini -t ${threads} -a true -i ${sample_id}.bam -o ${sample_id}.${prefix}_SNPs --count_matrix ${snp_count_matrix} --detailed_output=all
+    python3 SNP_Verification.py -c config.ini -t ${task.cpus} -a true -i ${sample_id}.bam -o ${sample_id}.${params.prefix}_SNPs --count_matrix ${snp_count_matrix} --detailed_output=all
 
     python3 $baseDir/bin/extract_snp_column.py \
       --sample-id "${sample_id}" \
-      --matrix ${sample_id}.${prefix}_SNPs/"${sample_id}.${prefix}_SNPs_${snp_count_matrix}" \
+      --matrix ${sample_id}.${prefix}_SNPs/"${sample_id}.${params.prefix}_SNPs_${snp_count_matrix}" \
       --out-tsv "${sample_id}.SNP_confirmed_gene.tsv"
     """
 }

--- a/modules/Resistome/resistome.nf
+++ b/modules/Resistome/resistome.nf
@@ -68,7 +68,7 @@ process runresistome {
     set -euo pipefail
 
     # Check if BAM has any alignments
-    aln_count=\$(\$SAMTOOLS view -c ${bam} 2>/dev/null || echo 0)
+    aln_count=(\$SAMTOOLS view -c ${bam} 2>/dev/null || echo 0)
 
     if [ "\$aln_count" -gt 0 ]; then
         \$SAMTOOLS view -h ${bam} > ${sample_id}.sam
@@ -108,7 +108,7 @@ process resistomeresults {
         path("${params.prefix}_analytic_matrix.csv"), emit: snp_count_matrix, optional: true
     script:
     """
-    ${\$PYTHON3} $baseDir/bin/amr_long_to_wide.py -i ${resistomes} -o ${params.prefix}_analytic_matrix.csv
+    \$PYTHON3 $baseDir/bin/amr_long_to_wide.py -i ${resistomes} -o ${params.prefix}_analytic_matrix.csv
     """
 }
 
@@ -278,7 +278,7 @@ process snpresults {
 
     script:
     """
-    ${\$PYTHON3} $baseDir/bin/snp_long_to_wide.py -i ${snp_counts} -o SNPconfirmed_${prefix}_analytic_matrix.csv
+    \$PYTHON3 $baseDir/bin/snp_long_to_wide.py -i ${snp_counts} -o SNPconfirmed_${prefix}_analytic_matrix.csv
     """
 }
 

--- a/modules/Resistome/resistome.nf
+++ b/modules/Resistome/resistome.nf
@@ -1,17 +1,8 @@
 // Resistome
 
-if( params.annotation ) {
-    annotation = file(params.annotation)
-    if( !annotation.exists() ) return annotation_error(annotation)
-}
-
-
 process build_dependencies {
     tag "Download SNP dependencies"
     label "nano"
-
-    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
-    maxRetries 3
 
     publishDir "${baseDir}/bin/", mode: "copy"
 
@@ -20,6 +11,7 @@ process build_dependencies {
         path("resistome"), emit: resistomeanalyzer
         path("AmrPlusPlus_SNP/*"), emit: amrsnp
 
+    script:
     """
     # Uncomment these sections once the v2 rarefactionanalyzer and resistomeanalyzer repositories are updated, remove cp lines
     #git clone https://github.com/cdeanj/rarefactionanalyzer.git
@@ -54,9 +46,6 @@ process build_dependencies {
 process runresistome {
     tag { sample_id }
     label "medium"
-
-    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
-    maxRetries 3
 
     publishDir "${params.output}/ResistomeAnalysis", mode: "copy",
         saveAs: { filename ->
@@ -107,9 +96,6 @@ process runresistome {
 process resistomeresults {
     tag "Make AMR count matrix"
     label "small"
-
-    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
-    maxRetries 3
     
     publishDir "${params.output}/Results", mode: "copy"
 
@@ -120,7 +106,7 @@ process resistomeresults {
     output:
         path("${params.prefix}_analytic_matrix.csv"), emit: raw_count_matrix
         path("${params.prefix}_analytic_matrix.csv"), emit: snp_count_matrix, optional: true
-
+    script:
     """
     ${PYTHON3} $baseDir/bin/amr_long_to_wide.py -i ${resistomes} -o ${params.prefix}_analytic_matrix.csv
     """
@@ -129,9 +115,6 @@ process resistomeresults {
 process runrarefaction {
     tag { sample_id }
     label "small"
-
-    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
-    maxRetries 3
 
     publishDir "${params.output}/ResistomeAnalysis", mode: "copy",
         saveAs: { filename ->
@@ -187,9 +170,6 @@ process plotrarefaction {
     tag "Plot rarefaction results"
     label "micro"
 
-    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
-    maxRetries 3
-
     publishDir "${params.output}/ResistomeAnalysis", mode: "copy",
         saveAs: { filename ->
             if(filename.indexOf(".png") > 0) "Rarefaction/Figures/$filename"
@@ -203,6 +183,7 @@ process plotrarefaction {
     output:
         path("*.png"), emit: plots
 
+    script:
     """
     mkdir -p data/
     mv *.tsv data/
@@ -220,14 +201,14 @@ process old_runsnp {
                 if(filename.indexOf(".tsv") > 0) "SNP_verification_counts/$filename"
                 else "SNP_detailed_output/$filename"
             }
-    errorStrategy = 'ignore'
+
     input:
         tuple val(sample_id), path(bam)
         path(snp_count_matrix)
 
     output:
         path("${sample_id}.SNP_confirmed_gene.tsv"), emit: snp_counts
-
+    script:
     """
     cp -rsa $baseDir/bin/AmrPlusPlus_SNP/* .
 
@@ -254,7 +235,7 @@ process runsnp {
                 if(filename.indexOf(".tsv") > 0) "SNP_verification_counts/$filename"
                 else "SNP_detailed_output/$filename"
             }
-    errorStrategy = 'ignore'
+
     input:
         tuple val(sample_id), path(bam)
         path(snp_count_matrix)
@@ -264,7 +245,7 @@ process runsnp {
         path("${sample_id}.${prefix}_SNPs/${sample_id}/${sample_id}.${params.prefix}_SNPs_SNPs_resistant_reads.txt") , optional: true
         path("${sample_id}.${prefix}_SNPs/${sample_id}/${sample_id}.${params.prefix}_SNPs_snp_coverage_stats.csv")
         path("${sample_id}.${prefix}_SNPs/${sample_id}/${sample_id}.${params.prefix}_SNPs_snp_verification_summary.csv")
-
+    script:
     """
     cp -rsa $baseDir/bin/AmrPlusPlus_SNP/* .
 
@@ -285,13 +266,8 @@ process runsnp {
 process snpresults {
     tag "Make SNP-confirmed matrix"
     label "micro"
-
-    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
-    maxRetries 3
     
     publishDir "${params.output}/Results", mode: "copy"
-
-    errorStrategy = 'ignore'
 
     input:
         path(snp_counts)
@@ -300,10 +276,9 @@ process snpresults {
     output:
         path("*_analytic_matrix.csv"), emit: snp_matrix
 
+    script:
     """
-
     ${PYTHON3} $baseDir/bin/snp_long_to_wide.py -i ${snp_counts} -o SNPconfirmed_${prefix}_analytic_matrix.csv
-
     """
 }
 

--- a/modules/Resistome/resistome.nf
+++ b/modules/Resistome/resistome.nf
@@ -288,7 +288,7 @@ process runsnp {
 
     python3 $baseDir/bin/extract_snp_column.py \
       --sample-id "${sample_id}" \
-      --matrix ${sample_id}.${prefix}_SNPs/"${sample_id}.${prefix}_SNPs${snp_count_matrix}" \
+      --matrix ${sample_id}.${prefix}_SNPs/"${sample_id}.${prefix}_SNPs_${snp_count_matrix}" \
       --out-tsv "${sample_id}.SNP_confirmed_gene.tsv"
     """
 }

--- a/modules/Resistome/resistome.nf
+++ b/modules/Resistome/resistome.nf
@@ -451,11 +451,11 @@ process snpresults {
         val  prefix
 
     output:
-        path("*_analytic_matrix.csv"), emit: snp_matrix
+        path("*${params.min_gene_fraction}gf_${params.min_query_coverage}qc_analytic_matrix.csv"), emit: snp_matrix
 
     script:
     """
-    \$PYTHON3 $baseDir/bin/snp_long_to_wide.py -i ${snp_counts} -o SNPconfirmed_${prefix}_analytic_matrix.csv
+    \$PYTHON3 $baseDir/bin/snp_long_to_wide.py -i ${snp_counts} -o SNPconfirmed_${prefix}_${params.min_gene_fraction}gf_${params.min_query_coverage}qc_analytic_matrix.csv
     """
 }
 

--- a/modules/Resistome/resistome.nf
+++ b/modules/Resistome/resistome.nf
@@ -257,11 +257,11 @@ process resistomeresults {
         val  prefix
 
     output:
-        path("${params.prefix}_analytic_matrix.csv"), emit: raw_count_matrix
-        path("${params.prefix}_analytic_matrix.csv"), emit: snp_count_matrix, optional: true
+        path("${params.prefix}_${params.min_gene_fraction}gf_${params.min_query_coverage}qc_analytic_matrix.csv"), emit: raw_count_matrix
+        path("${params.prefix}_${params.min_gene_fraction}gf_${params.min_query_coverage}qc_analytic_matrix.csv"), emit: snp_count_matrix, optional: true
     script:
     """
-    \$PYTHON3 $baseDir/bin/amr_long_to_wide.py -i ${resistomes} -o ${params.prefix}_analytic_matrix.csv
+    \$PYTHON3 $baseDir/bin/amr_long_to_wide.py -i ${resistomes} -o ${params.prefix}_${params.min_gene_fraction}gf_${params.min_query_coverage}qc_analytic_matrix.csv
     """
 }
 

--- a/modules/Resistome/resistome.nf
+++ b/modules/Resistome/resistome.nf
@@ -68,10 +68,10 @@ process runresistome {
     set -euo pipefail
 
     # Check if BAM has any alignments
-    aln_count=\$(${SAMTOOLS} view -c ${bam} 2>/dev/null || echo 0)
+    aln_count=\$(\$SAMTOOLS view -c ${bam} 2>/dev/null || echo 0)
 
     if [ "\$aln_count" -gt 0 ]; then
-        ${SAMTOOLS} view -h ${bam} > ${sample_id}.sam
+        \$SAMTOOLS view -h ${bam} > ${sample_id}.sam
 
         $resistome -ref_fp ${amr} \\
           -annot_fp ${annotation} \\
@@ -108,7 +108,7 @@ process resistomeresults {
         path("${params.prefix}_analytic_matrix.csv"), emit: snp_count_matrix, optional: true
     script:
     """
-    ${PYTHON3} $baseDir/bin/amr_long_to_wide.py -i ${resistomes} -o ${params.prefix}_analytic_matrix.csv
+    ${\$PYTHON3} $baseDir/bin/amr_long_to_wide.py -i ${resistomes} -o ${params.prefix}_analytic_matrix.csv
     """
 }
 
@@ -135,10 +135,10 @@ process runrarefaction {
     """
     set -euo pipefail
 
-    aln_count=\$(${SAMTOOLS} view -c ${bam} 2>/dev/null || echo 0)
+    aln_count=(\$SAMTOOLS view -c ${bam} 2>/dev/null || echo 0)
 
     if [ "\$aln_count" -gt 0 ]; then
-        ${SAMTOOLS} view -h ${bam} > ${sample_id}.sam
+        \$SAMTOOLS view -h ${bam} > ${sample_id}.sam
 
         $rarefaction \\
           -ref_fp ${amr} \\
@@ -217,9 +217,9 @@ process old_runsnp {
         mv ${bam} ${sample_id}.bam
     fi
 
-    python3 SNP_Verification.py -c config.ini -t ${task.cpus} -a true -i ${sample_id}.bam -o ${sample_id}.${prefix}_SNPs --count_matrix ${snp_count_matrix} --detailed_output=all
+    \$PYTHON3 SNP_Verification.py -c config.ini -t ${task.cpus} -a true -i ${sample_id}.bam -o ${sample_id}.${params.prefix}_SNPs --count_matrix ${snp_count_matrix} --detailed_output=all
 
-    python3 $baseDir/bin/extract_snp_column.py \
+    \$PYTHON3 $baseDir/bin/extract_snp_column.py \
       --sample-id "${sample_id}" \
       --matrix "${sample_id}.${params.prefix}_SNPs${snp_count_matrix}" \
       --out-tsv "${sample_id}.SNP_confirmed_gene.tsv"
@@ -242,9 +242,9 @@ process runsnp {
 
     output:
         path("${sample_id}.SNP_confirmed_gene.tsv"), emit: snp_counts
-        path("${sample_id}.${prefix}_SNPs/${sample_id}/${sample_id}.${params.prefix}_SNPs_SNPs_resistant_reads.txt") , optional: true
-        path("${sample_id}.${prefix}_SNPs/${sample_id}/${sample_id}.${params.prefix}_SNPs_snp_coverage_stats.csv")
-        path("${sample_id}.${prefix}_SNPs/${sample_id}/${sample_id}.${params.prefix}_SNPs_snp_verification_summary.csv")
+        path("${sample_id}.${params.prefix}_SNPs/${sample_id}/${sample_id}.${params.prefix}_SNPs_SNPs_resistant_reads.txt") , optional: true
+        path("${sample_id}.${params.prefix}_SNPs/${sample_id}/${sample_id}.${params.prefix}_SNPs_snp_coverage_stats.csv")
+        path("${sample_id}.${params.prefix}_SNPs/${sample_id}/${sample_id}.${params.prefix}_SNPs_snp_verification_summary.csv")
     script:
     """
     cp -rsa $baseDir/bin/AmrPlusPlus_SNP/* .
@@ -254,11 +254,11 @@ process runsnp {
         mv ${bam} ${sample_id}.bam
     fi
 
-    python3 SNP_Verification.py -c config.ini -t ${task.cpus} -a true -i ${sample_id}.bam -o ${sample_id}.${params.prefix}_SNPs --count_matrix ${snp_count_matrix} --detailed_output=all
+    \$PYTHON3 SNP_Verification.py -c config.ini -t ${task.cpus} -a true -i ${sample_id}.bam -o ${sample_id}.${params.prefix}_SNPs --count_matrix ${snp_count_matrix} --detailed_output=all
 
-    python3 $baseDir/bin/extract_snp_column.py \
+    \$PYTHON3 $baseDir/bin/extract_snp_column.py \
       --sample-id "${sample_id}" \
-      --matrix ${sample_id}.${prefix}_SNPs/"${sample_id}.${params.prefix}_SNPs_${snp_count_matrix}" \
+      --matrix ${sample_id}.${params.prefix}_SNPs/"${sample_id}.${params.prefix}_SNPs_${snp_count_matrix}" \
       --out-tsv "${sample_id}.SNP_confirmed_gene.tsv"
     """
 }
@@ -278,7 +278,7 @@ process snpresults {
 
     script:
     """
-    ${PYTHON3} $baseDir/bin/snp_long_to_wide.py -i ${snp_counts} -o SNPconfirmed_${prefix}_analytic_matrix.csv
+    ${\$PYTHON3} $baseDir/bin/snp_long_to_wide.py -i ${snp_counts} -o SNPconfirmed_${prefix}_analytic_matrix.csv
     """
 }
 

--- a/modules/Trimming/trimmomatic.nf
+++ b/modules/Trimming/trimmomatic.nf
@@ -59,7 +59,7 @@ process runqc_se {
   tag { sample_id }
   label "small"
 
-  publishDir "${params.output}/QC_trimming_SE", mode: 'copy', pattern: '*.fastq.gz',
+  publishDir "${params.output}/QC_trimming/Single", mode: 'copy', pattern: '*.fastq.gz',
     saveAs: { fn -> fn }
 
   input:

--- a/modules/Trimming/trimmomatic.nf
+++ b/modules/Trimming/trimmomatic.nf
@@ -1,17 +1,8 @@
 include {adapter_error} from './modules/nf-functions.nf'
 
-if( params.adapters ) {
-    adapters = file(params.adapters)
-    if( !adapters.exists() ) return adapter_error(adapters)
-}
-
-
 process runqc {
     tag { sample_id }
     label "micro_long"
-
-    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
-    maxRetries 3
 
     publishDir "${params.output}/QC_trimming", mode: 'copy', pattern: '*.fastq.gz',
         saveAs: { filename ->
@@ -78,9 +69,6 @@ process runqc_se {
 process QCstats {
     tag "Make QC summary file"
     label "small"
-
-    errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
-    maxRetries 3
 
     publishDir "${params.output}/Results", mode: 'copy',
         saveAs: { filename ->

--- a/modules/Trimming/trimmomatic.nf
+++ b/modules/Trimming/trimmomatic.nf
@@ -18,7 +18,7 @@ process runqc {
         tuple val(sample_id), path("${sample_id}*P.fastq.gz"), emit: paired_fastq
         tuple val(sample_id), path("${sample_id}*U.fastq.gz"), emit: unpaired_fastq
         path("${sample_id}.trimmomatic.stats.log"), emit: trimmomatic_stats
-
+   script:
     """
      ${TRIMMOMATIC} \
       PE \
@@ -50,6 +50,7 @@ process runqc_se {
     path("${sample_id}.trimmomatic.stats.log"),                              emit: trimmomatic_stats    // keep if you still want the stderr log
     path("${sample_id}.trimmomatic.summary.txt"),                            emit: trimmomatic_summary  // NEW: uniform summary
 
+  script:
   """
   ${TRIMMOMATIC} \
     SE \
@@ -82,26 +83,28 @@ process QCstats {
     output:
         path("trimmomatic.stats"), emit: combo_trim_stats
 
+   script:
     """
     ${PYTHON3} $baseDir/bin/trimmomatic_stats.py -i ${stats} -o trimmomatic.stats
     """
 }
 
 process QCstats_SE {
-  tag "Make QC summary file (SE)"
-  label "small"
+    tag "Make QC summary file (SE)"
+    label "small"
 
-  publishDir "${params.output}/Results", mode: 'copy',
-    saveAs: { fn -> fn.endsWith(".stats") ? "Stats/$fn" : null }
+    publishDir "${params.output}/Results", mode: 'copy',
+       saveAs: { fn -> fn.endsWith(".stats") ? "Stats/$fn" : null }
 
-  input:
-    file(summaries)
+    input:
+      file(summaries)
 
-  output:
-    path("trimmomatic.stats"), emit: combo_trim_stats
+    output:
+      path("trimmomatic.stats"), emit: combo_trim_stats
 
-  """
+    script:
+    """
 
-  """
+    """
 }
 

--- a/modules/Trimming/trimmomatic.nf
+++ b/modules/Trimming/trimmomatic.nf
@@ -1,5 +1,3 @@
-include {adapter_error} from './modules/nf-functions.nf'
-
 process runqc {
     tag { sample_id }
     label "micro_long"
@@ -20,7 +18,7 @@ process runqc {
         path("${sample_id}.trimmomatic.stats.log"), emit: trimmomatic_stats
    script:
     """
-     ${TRIMMOMATIC} \
+     \$TRIMMOMATIC \
       PE \
       -threads ${task.cpus} \
       ${reads[0]} ${reads[1]} ${sample_id}.1P.fastq.gz ${sample_id}.1U.fastq.gz ${sample_id}.2P.fastq.gz ${sample_id}.2U.fastq.gz \
@@ -52,7 +50,7 @@ process runqc_se {
 
   script:
   """
-  ${TRIMMOMATIC} \
+  \$TRIMMOMATIC \
     SE \
     -threads ${task.cpus} \
     -summary ${sample_id}.trimmomatic.summary.txt \
@@ -85,7 +83,7 @@ process QCstats {
 
    script:
     """
-    ${PYTHON3} $baseDir/bin/trimmomatic_stats.py -i ${stats} -o trimmomatic.stats
+    \$PYTHON3 $baseDir/bin/trimmomatic_stats.py -i ${stats} -o trimmomatic.stats
     """
 }
 

--- a/modules/Trimming/trimmomatic.nf
+++ b/modules/Trimming/trimmomatic.nf
@@ -5,17 +5,6 @@ if( params.adapters ) {
     if( !adapters.exists() ) return adapter_error(adapters)
 }
 
-threads = params.threads
-min = params.min
-max = params.max
-skip = params.skip
-samples = params.samples
-
-leading = params.leading
-trailing = params.trailing
-slidingwindow = params.slidingwindow
-minlen = params.minlen
-crop_len = params.crop_len
 
 process runqc {
     tag { sample_id }
@@ -42,14 +31,14 @@ process runqc {
     """
      ${TRIMMOMATIC} \
       PE \
-      -threads ${threads} \
+      -threads ${task.cpus} \
       ${reads[0]} ${reads[1]} ${sample_id}.1P.fastq.gz ${sample_id}.1U.fastq.gz ${sample_id}.2P.fastq.gz ${sample_id}.2U.fastq.gz \
-      ILLUMINACLIP:${adapters}:2:30:10:3:TRUE \
-      LEADING:${leading} \
-      TRAILING:${trailing} \
-      SLIDINGWINDOW:${slidingwindow} \
-      MINLEN:${minlen} \
-      CROP:${crop_len} \
+      ILLUMINACLIP:${params.adapters}:2:30:10:3:TRUE \
+      LEADING:${params.leading} \
+      TRAILING:${params.trailing} \
+      SLIDINGWINDOW:${params.slidingwindow} \
+      MINLEN:${params.minlen} \
+      CROP:${params.crop_len} \
       2> ${sample_id}.trimmomatic.stats.log
       
     """
@@ -73,15 +62,15 @@ process runqc_se {
   """
   ${TRIMMOMATIC} \
     SE \
-    -threads ${threads} \
+    -threads ${task.cpus} \
     -summary ${sample_id}.trimmomatic.summary.txt \
     ${read} ${sample_id}.trimmed.fastq.gz \
-    ILLUMINACLIP:${adapters}:2:30:10:3:TRUE \
-    LEADING:${leading} \
-    TRAILING:${trailing} \
-    SLIDINGWINDOW:${slidingwindow} \
-    MINLEN:${minlen} \
-    CROP:${crop_len} \
+    ILLUMINACLIP:${params.adapters}:2:30:10:3:TRUE \
+    LEADING:${params.leading} \
+    TRAILING:${params.trailing} \
+    SLIDINGWINDOW:${params.slidingwindow} \
+    MINLEN:${params.minlen} \
+    CROP:${params.crop_len} \
     2> ${sample_id}.trimmomatic.stats.log
   """
 }

--- a/modules/Trimming/trimmomatic.nf
+++ b/modules/Trimming/trimmomatic.nf
@@ -1,4 +1,4 @@
-include {adapter_error} from "$baseDir/modules/nf-functions.nf"
+include {adapter_error} from './modules/nf-functions.nf'
 
 if( params.adapters ) {
     adapters = file(params.adapters)

--- a/params.config
+++ b/params.config
@@ -120,4 +120,6 @@ env {
     /* These next tools are optional depending on which analyses you want to run */
     KRAKEN2 = "kraken2"
     QIIME = "qiime"
+    FASTQC = "fastqc"
+    MULTIQC = "multiqc"
 }

--- a/params.config
+++ b/params.config
@@ -99,6 +99,24 @@ params {
 
     /* qiime2 bayes classifier */
     dada2_db = "$baseDir/data/qiime/gg-13-8-99-515-806-nb-classifier.qza"
+
+    /* alignment_analyzer.py options */
+    min_gene_fraction     = 0
+    min_query_coverage    = 0
+    min_mapq              = 0
+    count_mode            = "fragment"  // DEFAULT. fragment = merged & unmerged weighted equally.
+    group_aware           = "Y"         // DEFAULT ON. Same-Group mate disagreements -> 1 hit
+                                        // (tie-break: higher match_qcov).
+    edge_aware_qcov       = "Y"         // DEFAULT ON. Coverage-anchored qcov. Read-axis only.
+    include_supplementary = "N"
+    cigar_aware_coverage  = "Y"
+
+    /* Coverage threshold sweep */
+    sweep_exclude_snp     = "Y"
+    sweep_edge_aware_qcov = "Y"
+
+    /* Optional read deduplication (Clumpify) after QC trimming */
+    read_dedup            = "Y"         // Y inserts dedup between trim and host removal
 }
 
 
@@ -122,4 +140,5 @@ env {
     QIIME = "qiime"
     FASTQC = "fastqc"
     MULTIQC = "multiqc"
+    RSCRIPT = "Rscript"
 }

--- a/params.config
+++ b/params.config
@@ -57,15 +57,11 @@ params {
     /* Add SNP analysis */
     snp = "Y"
 
-    /* Resistome threshold */
+    /* Resistome threshold - associated with outdated resistomeanalyzer, now replaced with alignment_analyzer.py */
     threshold = 0
 
     /* Add rarefaction analysis */ 
     rarefaction = "N"
-
-    /* Add deduplicaation analysis */
-    deduped = "Y"
-    prefix = "AMR"
 
     /* Number of threads */
     threads = 4
@@ -116,7 +112,11 @@ params {
     sweep_edge_aware_qcov = "Y"
 
     /* Optional read deduplication (Clumpify) after QC trimming */
-    read_dedup            = "Y"         // Y inserts dedup between trim and host removal
+    read_dedup            = "N"         // Y inserts dedup between trim and host removal
+
+    /* Add read deduplicaation analysis */
+    deduped = "N"
+    prefix = "AMR"
 }
 
 

--- a/params.config
+++ b/params.config
@@ -24,6 +24,9 @@ params {
     /* Optional input for bam files for use with "--pipeline bam_resistome" */
     bam_files = null
 
+    /* Default memory to run clumpify */
+    clumpify_mem_gb = 8
+
     /* Location of reference/host genome */
     host = "${baseDir}/data/host/chr21.fasta.gz"
 

--- a/subworkflows/AMR++_SE_standard.nf
+++ b/subworkflows/AMR++_SE_standard.nf
@@ -18,8 +18,15 @@ workflow SE_AMRplusplus {
         // Trimming
         FASTQ_TRIM_SE_WF(read_se_ch)
 
+        if( params.read_dedup == "Y" ) {
+            FASTQ_DEDUP_SE_WF( FASTQ_TRIM_SE_WF.out.se_fastq )
+            reads_for_host = FASTQ_DEDUP_SE_WF.out.deduped_reads
+        } else {
+            reads_for_host = FASTQ_TRIM_SE_WF.out.trimmed_reads
+        }
+
         // 2) Host removal (SE) on trimmed reads
-        FASTQ_RM_HOST_SE_WF( hostfasta, FASTQ_TRIM_SE_WF.out.trimmed_reads )
+        FASTQ_RM_HOST_SE_WF( hostfasta, reads_for_host )
 
         // 4) Branch A: Resistome
         FASTQ_RESISTOME_SE_WF( FASTQ_RM_HOST_SE_WF.out.nonhost_reads, amr, annotation )

--- a/subworkflows/AMR++_SE_standard.nf
+++ b/subworkflows/AMR++_SE_standard.nf
@@ -3,6 +3,7 @@ include { FASTQ_TRIM_SE_WF } from './fastq_QC_trimming.nf'
 include { FASTQ_RM_HOST_SE_WF   } from './fastq_host_removal.nf'
 include { FASTQ_RESISTOME_SE_WF } from './fastq_resistome.nf'
 include { FASTQ_KRAKEN_SE_WF    } from './fastq_microbiome.nf'
+include { FASTQ_DEDUP_SE_WF } from './fastq_deduplicate.nf'
 
 workflow SE_AMRplusplus {
     take: 

--- a/subworkflows/AMR++_SE_standard.nf
+++ b/subworkflows/AMR++_SE_standard.nf
@@ -22,6 +22,7 @@ workflow SE_AMRplusplus {
         if( params.read_dedup == "Y" ) {
             FASTQ_DEDUP_SE_WF( FASTQ_TRIM_SE_WF.out.se_fastq )
             reads_for_host = FASTQ_DEDUP_SE_WF.out.deduped_reads
+                .map { sample_id, r1, r2 -> tuple(sample_id, [r1, r2]) }
         } else {
             reads_for_host = FASTQ_TRIM_SE_WF.out.trimmed_reads
         }

--- a/subworkflows/AMR++_SE_standard.nf
+++ b/subworkflows/AMR++_SE_standard.nf
@@ -1,8 +1,8 @@
-include { FASTQ_QC_SE_WF } from "$baseDir/subworkflows/fastq_information.nf"
-include { FASTQ_TRIM_SE_WF } from "$baseDir/subworkflows/fastq_QC_trimming.nf"
-include { FASTQ_RM_HOST_SE_WF   } from "$baseDir/subworkflows/fastq_host_removal.nf"
-include { FASTQ_RESISTOME_SE_WF } from "$baseDir/subworkflows/fastq_resistome.nf"
-include { FASTQ_KRAKEN_SE_WF    } from "$baseDir/subworkflows/fastq_microbiome.nf"
+include { FASTQ_QC_SE_WF } from './subworkflows/fastq_information.nf'
+include { FASTQ_TRIM_SE_WF } from './subworkflows/fastq_QC_trimming.nf'
+include { FASTQ_RM_HOST_SE_WF   } from './subworkflows/fastq_host_removal.nf'
+include { FASTQ_RESISTOME_SE_WF } from './subworkflows/fastq_resistome.nf'
+include { FASTQ_KRAKEN_SE_WF    } from './subworkflows/fastq_microbiome.nf'
 
 workflow SE_AMRplusplus {
     take: 

--- a/subworkflows/AMR++_SE_standard.nf
+++ b/subworkflows/AMR++_SE_standard.nf
@@ -1,8 +1,8 @@
-include { FASTQ_QC_SE_WF } from './subworkflows/fastq_information.nf'
-include { FASTQ_TRIM_SE_WF } from './subworkflows/fastq_QC_trimming.nf'
-include { FASTQ_RM_HOST_SE_WF   } from './subworkflows/fastq_host_removal.nf'
-include { FASTQ_RESISTOME_SE_WF } from './subworkflows/fastq_resistome.nf'
-include { FASTQ_KRAKEN_SE_WF    } from './subworkflows/fastq_microbiome.nf'
+include { FASTQ_QC_SE_WF } from './fastq_information.nf'
+include { FASTQ_TRIM_SE_WF } from './fastq_QC_trimming.nf'
+include { FASTQ_RM_HOST_SE_WF   } from './fastq_host_removal.nf'
+include { FASTQ_RESISTOME_SE_WF } from './fastq_resistome.nf'
+include { FASTQ_KRAKEN_SE_WF    } from './fastq_microbiome.nf'
 
 workflow SE_AMRplusplus {
     take: 

--- a/subworkflows/AMR++_SE_standard_wKraken.nf
+++ b/subworkflows/AMR++_SE_standard_wKraken.nf
@@ -18,8 +18,15 @@ workflow SE_AMRplusplus_wKraken {
         // Trimming
         FASTQ_TRIM_SE_WF(read_se_ch)
 
+        if( params.read_dedup == "Y" ) {
+            FASTQ_DEDUP_SE_WF( FASTQ_TRIM_SE_WF.out.se_fastq )
+            reads_for_host = FASTQ_DEDUP_SE_WF.out.deduped_reads
+        } else {
+            reads_for_host = FASTQ_TRIM_SE_WF.out.trimmed_reads
+        }
+
         // 2) Host removal (SE) on trimmed reads
-        FASTQ_RM_HOST_SE_WF( hostfasta, FASTQ_TRIM_SE_WF.out.trimmed_reads )
+        FASTQ_RM_HOST_SE_WF( hostfasta, reads_for_host)
 
         // 4) Branch A: Resistome
         FASTQ_RESISTOME_SE_WF( FASTQ_RM_HOST_SE_WF.out.nonhost_reads, amr, annotation )

--- a/subworkflows/AMR++_SE_standard_wKraken.nf
+++ b/subworkflows/AMR++_SE_standard_wKraken.nf
@@ -1,8 +1,8 @@
-include { FASTQ_QC_SE_WF } from "$baseDir/subworkflows/fastq_information.nf"
-include { FASTQ_TRIM_SE_WF } from "$baseDir/subworkflows/fastq_QC_trimming.nf"
-include { FASTQ_RM_HOST_SE_WF   } from "$baseDir/subworkflows/fastq_host_removal.nf"
-include { FASTQ_RESISTOME_SE_WF } from "$baseDir/subworkflows/fastq_resistome.nf"
-include { FASTQ_KRAKEN_SE_WF    } from "$baseDir/subworkflows/fastq_microbiome.nf"
+include { FASTQ_QC_SE_WF } from './subworkflows/fastq_information.nf'
+include { FASTQ_TRIM_SE_WF } from './subworkflows/fastq_QC_trimming.nf'
+include { FASTQ_RM_HOST_SE_WF   } from './subworkflows/fastq_host_removal.nf'
+include { FASTQ_RESISTOME_SE_WF } from './subworkflows/fastq_resistome.nf'
+include { FASTQ_KRAKEN_SE_WF    } from './subworkflows/fastq_microbiome.nf'
 
 workflow SE_AMRplusplus_wKraken {
     take: 

--- a/subworkflows/AMR++_SE_standard_wKraken.nf
+++ b/subworkflows/AMR++_SE_standard_wKraken.nf
@@ -22,6 +22,7 @@ workflow SE_AMRplusplus_wKraken {
         if( params.read_dedup == "Y" ) {
             FASTQ_DEDUP_SE_WF( FASTQ_TRIM_SE_WF.out.se_fastq )
             reads_for_host = FASTQ_DEDUP_SE_WF.out.deduped_reads
+                .map { sample_id, r1, r2 -> tuple(sample_id, [r1, r2]) }
         } else {
             reads_for_host = FASTQ_TRIM_SE_WF.out.trimmed_reads
         }

--- a/subworkflows/AMR++_SE_standard_wKraken.nf
+++ b/subworkflows/AMR++_SE_standard_wKraken.nf
@@ -3,6 +3,7 @@ include { FASTQ_TRIM_SE_WF } from './fastq_QC_trimming.nf'
 include { FASTQ_RM_HOST_SE_WF   } from './fastq_host_removal.nf'
 include { FASTQ_RESISTOME_SE_WF } from './fastq_resistome.nf'
 include { FASTQ_KRAKEN_SE_WF    } from './fastq_microbiome.nf'
+include { FASTQ_DEDUP_SE_WF } from './fastq_deduplicate.nf'
 
 workflow SE_AMRplusplus_wKraken {
     take: 

--- a/subworkflows/AMR++_SE_standard_wKraken.nf
+++ b/subworkflows/AMR++_SE_standard_wKraken.nf
@@ -1,8 +1,8 @@
-include { FASTQ_QC_SE_WF } from './subworkflows/fastq_information.nf'
-include { FASTQ_TRIM_SE_WF } from './subworkflows/fastq_QC_trimming.nf'
-include { FASTQ_RM_HOST_SE_WF   } from './subworkflows/fastq_host_removal.nf'
-include { FASTQ_RESISTOME_SE_WF } from './subworkflows/fastq_resistome.nf'
-include { FASTQ_KRAKEN_SE_WF    } from './subworkflows/fastq_microbiome.nf'
+include { FASTQ_QC_SE_WF } from './fastq_information.nf'
+include { FASTQ_TRIM_SE_WF } from './fastq_QC_trimming.nf'
+include { FASTQ_RM_HOST_SE_WF   } from './fastq_host_removal.nf'
+include { FASTQ_RESISTOME_SE_WF } from './fastq_resistome.nf'
+include { FASTQ_KRAKEN_SE_WF    } from './fastq_microbiome.nf'
 
 workflow SE_AMRplusplus_wKraken {
     take: 

--- a/subworkflows/AMR++_fast.nf
+++ b/subworkflows/AMR++_fast.nf
@@ -13,8 +13,15 @@ workflow FAST_AMRplusplus {
         FASTQ_QC_WF( read_pairs_ch )
         // runqc trimming
         FASTQ_TRIM_WF(read_pairs_ch)
+        
+        if( params.read_dedup == "Y" ) {
+            FASTQ_DEDUP_PE_WF( FASTQ_TRIM_WF.out.trimmed_reads )
+            reads_for_host = FASTQ_DEDUP_PE_WF.out.deduped_reads
+        } else {
+            reads_for_host = FASTQ_TRIM_WF.out.trimmed_reads
+        }
         // AMR alignment
-        FASTQ_RESISTOME_WF(FASTQ_TRIM_WF.out.trimmed_reads, amr,annotation)
+        FASTQ_RESISTOME_WF(reads_for_host, amr,annotation)
 
         
 }

--- a/subworkflows/AMR++_fast.nf
+++ b/subworkflows/AMR++_fast.nf
@@ -18,6 +18,7 @@ workflow FAST_AMRplusplus {
         if( params.read_dedup == "Y" ) {
             FASTQ_DEDUP_PE_WF( FASTQ_TRIM_WF.out.trimmed_reads )
             reads_for_host = FASTQ_DEDUP_PE_WF.out.deduped_reads
+                .map { sample_id, r1, r2 -> tuple(sample_id, [r1, r2]) }
         } else {
             reads_for_host = FASTQ_TRIM_WF.out.trimmed_reads
         }

--- a/subworkflows/AMR++_fast.nf
+++ b/subworkflows/AMR++_fast.nf
@@ -1,6 +1,6 @@
-include { FASTQ_QC_WF} from "$baseDir/subworkflows/fastq_information.nf"
-include { FASTQ_TRIM_WF } from "$baseDir/subworkflows/fastq_QC_trimming.nf"
-include { FASTQ_RESISTOME_WF } from "$baseDir/subworkflows/fastq_resistome.nf"
+include { FASTQ_QC_WF} from './subworkflows/fastq_information.nf'
+include { FASTQ_TRIM_WF } from './subworkflows/fastq_QC_trimming.nf'
+include { FASTQ_RESISTOME_WF } from './subworkflows/fastq_resistome.nf'
 
 workflow FAST_AMRplusplus {
     take: 

--- a/subworkflows/AMR++_fast.nf
+++ b/subworkflows/AMR++_fast.nf
@@ -1,6 +1,6 @@
-include { FASTQ_QC_WF} from './subworkflows/fastq_information.nf'
-include { FASTQ_TRIM_WF } from './subworkflows/fastq_QC_trimming.nf'
-include { FASTQ_RESISTOME_WF } from './subworkflows/fastq_resistome.nf'
+include { FASTQ_QC_WF} from './fastq_information.nf'
+include { FASTQ_TRIM_WF } from './fastq_QC_trimming.nf'
+include { FASTQ_RESISTOME_WF } from './fastq_resistome.nf'
 
 workflow FAST_AMRplusplus {
     take: 

--- a/subworkflows/AMR++_fast.nf
+++ b/subworkflows/AMR++_fast.nf
@@ -1,6 +1,7 @@
 include { FASTQ_QC_WF} from './fastq_information.nf'
 include { FASTQ_TRIM_WF } from './fastq_QC_trimming.nf'
 include { FASTQ_RESISTOME_WF } from './fastq_resistome.nf'
+include { FASTQ_DEDUP_PE_WF } from './fastq_deduplicate.nf'
 
 workflow FAST_AMRplusplus {
     take: 

--- a/subworkflows/AMR++_merged_standard.nf
+++ b/subworkflows/AMR++_merged_standard.nf
@@ -1,8 +1,8 @@
-include { FASTQ_QC_WF } from "$baseDir/subworkflows/fastq_information.nf"
-include { FASTQ_TRIM_WF } from "$baseDir/subworkflows/fastq_QC_trimming.nf"
-include { FASTQ_MERGE_WF } from "$baseDir/subworkflows/fastq_merging.nf"
-include { MERGED_FASTQ_RM_HOST_WF } from "$baseDir/subworkflows/fastq_host_removal.nf" 
-include { MERGED_FASTQ_RESISTOME_WF } from "$baseDir/subworkflows/fastq_resistome.nf"
+include { FASTQ_QC_WF } from './subworkflows/fastq_information.nf'
+include { FASTQ_TRIM_WF } from './subworkflows/fastq_QC_trimming.nf'
+include { FASTQ_MERGE_WF } from './subworkflows/fastq_merging.nf'
+include { MERGED_FASTQ_RM_HOST_WF } from './subworkflows/fastq_host_removal.nf'
+include { MERGED_FASTQ_RESISTOME_WF } from './subworkflows/fastq_resistome.nf'
 
 workflow STANDARD_merged_AMRplusplus {
     take: 

--- a/subworkflows/AMR++_merged_standard.nf
+++ b/subworkflows/AMR++_merged_standard.nf
@@ -21,6 +21,7 @@ workflow STANDARD_merged_AMRplusplus {
         if( params.read_dedup == "Y" ) {
             FASTQ_DEDUP_PE_WF( FASTQ_TRIM_WF.out.trimmed_reads )
             reads_for_merge = FASTQ_DEDUP_PE_WF.out.deduped_reads
+                .map { sample_id, r1, r2 -> tuple(sample_id, [r1, r2]) }
         } else {
             reads_for_merge = FASTQ_TRIM_WF.out.trimmed_reads
         }

--- a/subworkflows/AMR++_merged_standard.nf
+++ b/subworkflows/AMR++_merged_standard.nf
@@ -1,8 +1,8 @@
-include { FASTQ_QC_WF } from './subworkflows/fastq_information.nf'
-include { FASTQ_TRIM_WF } from './subworkflows/fastq_QC_trimming.nf'
-include { FASTQ_MERGE_WF } from './subworkflows/fastq_merging.nf'
-include { MERGED_FASTQ_RM_HOST_WF } from './subworkflows/fastq_host_removal.nf'
-include { MERGED_FASTQ_RESISTOME_WF } from './subworkflows/fastq_resistome.nf'
+include { FASTQ_QC_WF } from './fastq_information.nf'
+include { FASTQ_TRIM_WF } from './fastq_QC_trimming.nf'
+include { FASTQ_MERGE_WF } from './fastq_merging.nf'
+include { MERGED_FASTQ_RM_HOST_WF } from './fastq_host_removal.nf'
+include { MERGED_FASTQ_RESISTOME_WF } from './fastq_resistome.nf'
 
 workflow STANDARD_merged_AMRplusplus {
     take: 

--- a/subworkflows/AMR++_merged_standard.nf
+++ b/subworkflows/AMR++_merged_standard.nf
@@ -16,8 +16,16 @@ workflow STANDARD_merged_AMRplusplus {
         FASTQ_QC_WF( read_pairs_ch )
         // runqc trimming
         FASTQ_TRIM_WF(read_pairs_ch)
+
+        if( params.read_dedup == "Y" ) {
+            FASTQ_DEDUP_PE_WF( FASTQ_TRIM_WF.out.trimmed_reads )
+            reads_for_merge = FASTQ_DEDUP_PE_WF.out.deduped_reads
+        } else {
+            reads_for_merge = FASTQ_TRIM_WF.out.trimmed_reads
+        }
+
         // merge reads
-        FASTQ_MERGE_WF( FASTQ_TRIM_WF.out.trimmed_reads )
+        FASTQ_MERGE_WF( reads_for_merge)
         
         FASTQ_MERGE_WF.out.merged
               .join( FASTQ_MERGE_WF.out.unmerged )

--- a/subworkflows/AMR++_merged_standard.nf
+++ b/subworkflows/AMR++_merged_standard.nf
@@ -3,6 +3,7 @@ include { FASTQ_TRIM_WF } from './fastq_QC_trimming.nf'
 include { FASTQ_MERGE_WF } from './fastq_merging.nf'
 include { MERGED_FASTQ_RM_HOST_WF } from './fastq_host_removal.nf'
 include { MERGED_FASTQ_RESISTOME_WF } from './fastq_resistome.nf'
+include { FASTQ_DEDUP_PE_WF } from './fastq_deduplicate.nf'
 
 workflow STANDARD_merged_AMRplusplus {
     take: 

--- a/subworkflows/AMR++_merged_standard_wKraken.nf
+++ b/subworkflows/AMR++_merged_standard_wKraken.nf
@@ -18,8 +18,15 @@ workflow STANDARD_merged_AMRplusplus_wKraken {
         FASTQ_QC_WF( read_pairs_ch )
         // runqc trimming
         FASTQ_TRIM_WF(read_pairs_ch)
+        
+        if( params.read_dedup == "Y" ) {
+            FASTQ_DEDUP_PE_WF( FASTQ_TRIM_WF.out.trimmed_reads )
+            reads_for_merge = FASTQ_DEDUP_PE_WF.out.deduped_reads
+        } else {
+            reads_for_merge = FASTQ_TRIM_WF.out.trimmed_reads
+        }
         // merge reads
-        FASTQ_MERGE_WF( FASTQ_TRIM_WF.out.trimmed_reads )
+        FASTQ_MERGE_WF( reads_for_merge )
         
         FASTQ_MERGE_WF.out.merged
               .join( FASTQ_MERGE_WF.out.unmerged )

--- a/subworkflows/AMR++_merged_standard_wKraken.nf
+++ b/subworkflows/AMR++_merged_standard_wKraken.nf
@@ -4,7 +4,7 @@ include { FASTQ_MERGE_WF } from './fastq_merging.nf'
 include { MERGED_FASTQ_RM_HOST_WF } from './fastq_host_removal.nf' 
 include { MERGED_FASTQ_RESISTOME_WF } from './fastq_resistome.nf'
 include { MERGED_FASTQ_KRAKEN_WF } from './fastq_microbiome.nf'
-
+include { FASTQ_DEDUP_PE_WF } from './fastq_deduplicate.nf'
 
 workflow STANDARD_merged_AMRplusplus_wKraken {
     take: 

--- a/subworkflows/AMR++_merged_standard_wKraken.nf
+++ b/subworkflows/AMR++_merged_standard_wKraken.nf
@@ -1,9 +1,9 @@
-include { FASTQ_QC_WF } from './subworkflows/fastq_information.nf'
-include { FASTQ_TRIM_WF } from './subworkflows/fastq_QC_trimming.nf'
-include { FASTQ_MERGE_WF } from './subworkflows/fastq_merging.nf'
-include { MERGED_FASTQ_RM_HOST_WF } from './subworkflows/fastq_host_removal.nf' 
-include { MERGED_FASTQ_RESISTOME_WF } from './subworkflows/fastq_resistome.nf'
-include { MERGED_FASTQ_KRAKEN_WF } from './subworkflows/fastq_microbiome.nf'
+include { FASTQ_QC_WF } from './fastq_information.nf'
+include { FASTQ_TRIM_WF } from './fastq_QC_trimming.nf'
+include { FASTQ_MERGE_WF } from './fastq_merging.nf'
+include { MERGED_FASTQ_RM_HOST_WF } from './fastq_host_removal.nf' 
+include { MERGED_FASTQ_RESISTOME_WF } from './fastq_resistome.nf'
+include { MERGED_FASTQ_KRAKEN_WF } from './fastq_microbiome.nf'
 
 
 workflow STANDARD_merged_AMRplusplus_wKraken {

--- a/subworkflows/AMR++_merged_standard_wKraken.nf
+++ b/subworkflows/AMR++_merged_standard_wKraken.nf
@@ -1,9 +1,9 @@
-include { FASTQ_QC_WF } from "$baseDir/subworkflows/fastq_information.nf"
-include { FASTQ_TRIM_WF } from "$baseDir/subworkflows/fastq_QC_trimming.nf"
-include { FASTQ_MERGE_WF } from "$baseDir/subworkflows/fastq_merging.nf"
-include { MERGED_FASTQ_RM_HOST_WF } from "$baseDir/subworkflows/fastq_host_removal.nf" 
-include { MERGED_FASTQ_RESISTOME_WF } from "$baseDir/subworkflows/fastq_resistome.nf"
-include { MERGED_FASTQ_KRAKEN_WF } from "$baseDir/subworkflows/fastq_microbiome.nf"
+include { FASTQ_QC_WF } from './subworkflows/fastq_information.nf'
+include { FASTQ_TRIM_WF } from './subworkflows/fastq_QC_trimming.nf'
+include { FASTQ_MERGE_WF } from './subworkflows/fastq_merging.nf'
+include { MERGED_FASTQ_RM_HOST_WF } from './subworkflows/fastq_host_removal.nf' 
+include { MERGED_FASTQ_RESISTOME_WF } from './subworkflows/fastq_resistome.nf'
+include { MERGED_FASTQ_KRAKEN_WF } from './subworkflows/fastq_microbiome.nf'
 
 
 workflow STANDARD_merged_AMRplusplus_wKraken {

--- a/subworkflows/AMR++_merged_standard_wKraken.nf
+++ b/subworkflows/AMR++_merged_standard_wKraken.nf
@@ -22,6 +22,7 @@ workflow STANDARD_merged_AMRplusplus_wKraken {
         if( params.read_dedup == "Y" ) {
             FASTQ_DEDUP_PE_WF( FASTQ_TRIM_WF.out.trimmed_reads )
             reads_for_merge = FASTQ_DEDUP_PE_WF.out.deduped_reads
+                .map { sample_id, r1, r2 -> tuple(sample_id, [r1, r2]) }
         } else {
             reads_for_merge = FASTQ_TRIM_WF.out.trimmed_reads
         }

--- a/subworkflows/AMR++_standard.nf
+++ b/subworkflows/AMR++_standard.nf
@@ -1,7 +1,7 @@
-include { FASTQ_QC_WF } from './subworkflows/fastq_information.nf'
-include { FASTQ_TRIM_WF } from './subworkflows/fastq_QC_trimming.nf'
-include { FASTQ_RM_HOST_WF } from './subworkflows/fastq_host_removal.nf' 
-include { FASTQ_RESISTOME_WF } from './subworkflows/fastq_resistome.nf'
+include { FASTQ_QC_WF } from './fastq_information.nf'
+include { FASTQ_TRIM_WF } from './fastq_QC_trimming.nf'
+include { FASTQ_RM_HOST_WF } from './fastq_host_removal.nf' 
+include { FASTQ_RESISTOME_WF } from './fastq_resistome.nf'
 
 workflow STANDARD_AMRplusplus {
     take: 

--- a/subworkflows/AMR++_standard.nf
+++ b/subworkflows/AMR++_standard.nf
@@ -15,8 +15,16 @@ workflow STANDARD_AMRplusplus {
         FASTQ_QC_WF( read_pairs_ch )
         // runqc trimming
         FASTQ_TRIM_WF(read_pairs_ch)
+
+        if( params.read_dedup == "Y" ) {
+            FASTQ_DEDUP_PE_WF( FASTQ_TRIM_WF.out.trimmed_reads )
+            reads_for_host = FASTQ_DEDUP_PE_WF.out.deduped_reads
+        } else {
+            reads_for_host = FASTQ_TRIM_WF.out.trimmed_reads
+        }
+
         // remove host DNA
-        FASTQ_RM_HOST_WF(hostfasta, FASTQ_TRIM_WF.out.trimmed_reads)
+        FASTQ_RM_HOST_WF(hostfasta, reads_for_host)
         // AMR alignment
         FASTQ_RESISTOME_WF(FASTQ_RM_HOST_WF.out.nonhost_reads, amr,annotation)
 

--- a/subworkflows/AMR++_standard.nf
+++ b/subworkflows/AMR++_standard.nf
@@ -20,6 +20,7 @@ workflow STANDARD_AMRplusplus {
         if( params.read_dedup == "Y" ) {
             FASTQ_DEDUP_PE_WF( FASTQ_TRIM_WF.out.trimmed_reads )
             reads_for_host = FASTQ_DEDUP_PE_WF.out.deduped_reads
+                .map { sample_id, r1, r2 -> tuple(sample_id, [r1, r2]) }
         } else {
             reads_for_host = FASTQ_TRIM_WF.out.trimmed_reads
         }

--- a/subworkflows/AMR++_standard.nf
+++ b/subworkflows/AMR++_standard.nf
@@ -2,6 +2,7 @@ include { FASTQ_QC_WF } from './fastq_information.nf'
 include { FASTQ_TRIM_WF } from './fastq_QC_trimming.nf'
 include { FASTQ_RM_HOST_WF } from './fastq_host_removal.nf' 
 include { FASTQ_RESISTOME_WF } from './fastq_resistome.nf'
+include { FASTQ_DEDUP_PE_WF } from './fastq_deduplicate.nf'
 
 workflow STANDARD_AMRplusplus {
     take: 

--- a/subworkflows/AMR++_standard.nf
+++ b/subworkflows/AMR++_standard.nf
@@ -1,7 +1,7 @@
-include { FASTQ_QC_WF } from "$baseDir/subworkflows/fastq_information.nf"
-include { FASTQ_TRIM_WF } from "$baseDir/subworkflows/fastq_QC_trimming.nf"
-include { FASTQ_RM_HOST_WF } from "$baseDir/subworkflows/fastq_host_removal.nf" 
-include { FASTQ_RESISTOME_WF } from "$baseDir/subworkflows/fastq_resistome.nf"
+include { FASTQ_QC_WF } from './subworkflows/fastq_information.nf'
+include { FASTQ_TRIM_WF } from './subworkflows/fastq_QC_trimming.nf'
+include { FASTQ_RM_HOST_WF } from './subworkflows/fastq_host_removal.nf' 
+include { FASTQ_RESISTOME_WF } from './subworkflows/fastq_resistome.nf'
 
 workflow STANDARD_AMRplusplus {
     take: 

--- a/subworkflows/AMR++_standard_wKraken.nf
+++ b/subworkflows/AMR++_standard_wKraken.nf
@@ -22,6 +22,7 @@ workflow STANDARD_AMRplusplus_wKraken {
         if( params.read_dedup == "Y" ) {
             FASTQ_DEDUP_PE_WF( FASTQ_TRIM_WF.out.trimmed_reads )
             reads_for_host = FASTQ_DEDUP_PE_WF.out.deduped_reads
+                .map { sample_id, r1, r2 -> tuple(sample_id, [r1, r2]) }
         } else {
             reads_for_host = FASTQ_TRIM_WF.out.trimmed_reads
         }

--- a/subworkflows/AMR++_standard_wKraken.nf
+++ b/subworkflows/AMR++_standard_wKraken.nf
@@ -1,8 +1,8 @@
-include { FASTQ_QC_WF } from "$baseDir/subworkflows/fastq_information.nf"
-include { FASTQ_TRIM_WF } from "$baseDir/subworkflows/fastq_QC_trimming.nf"
-include { FASTQ_RM_HOST_WF } from "$baseDir/subworkflows/fastq_host_removal.nf" 
-include { FASTQ_RESISTOME_WF } from "$baseDir/subworkflows/fastq_resistome.nf"
-include { FASTQ_KRAKEN_WF } from "$baseDir/subworkflows/fastq_microbiome.nf"
+include { FASTQ_QC_WF } from './subworkflows/fastq_information.nf'
+include { FASTQ_TRIM_WF } from './subworkflows/fastq_QC_trimming.nf'
+include { FASTQ_RM_HOST_WF } from './subworkflows/fastq_host_removal.nf' 
+include { FASTQ_RESISTOME_WF } from './subworkflows/fastq_resistome.nf'
+include { FASTQ_KRAKEN_WF } from './subworkflows/fastq_microbiome.nf'
 
 workflow STANDARD_AMRplusplus_wKraken {
     take: 

--- a/subworkflows/AMR++_standard_wKraken.nf
+++ b/subworkflows/AMR++_standard_wKraken.nf
@@ -17,8 +17,15 @@ workflow STANDARD_AMRplusplus_wKraken {
         FASTQ_QC_WF( read_pairs_ch )
         // runqc trimming
         FASTQ_TRIM_WF(read_pairs_ch)
+
+        if( params.read_dedup == "Y" ) {
+            FASTQ_DEDUP_PE_WF( FASTQ_TRIM_WF.out.trimmed_reads )
+            reads_for_host = FASTQ_DEDUP_PE_WF.out.deduped_reads
+        } else {
+            reads_for_host = FASTQ_TRIM_WF.out.trimmed_reads
+        }
         // remove host DNA
-        FASTQ_RM_HOST_WF(hostfasta, FASTQ_TRIM_WF.out.trimmed_reads)
+        FASTQ_RM_HOST_WF(hostfasta, reads_for_host)
         // AMR alignment
         FASTQ_RESISTOME_WF(FASTQ_RM_HOST_WF.out.nonhost_reads, amr,annotation)
         // Microbiome

--- a/subworkflows/AMR++_standard_wKraken.nf
+++ b/subworkflows/AMR++_standard_wKraken.nf
@@ -3,6 +3,7 @@ include { FASTQ_TRIM_WF } from './fastq_QC_trimming.nf'
 include { FASTQ_RM_HOST_WF } from './fastq_host_removal.nf' 
 include { FASTQ_RESISTOME_WF } from './fastq_resistome.nf'
 include { FASTQ_KRAKEN_WF } from './fastq_microbiome.nf'
+include { FASTQ_DEDUP_PE_WF } from './fastq_deduplicate.nf'
 
 workflow STANDARD_AMRplusplus_wKraken {
     take: 

--- a/subworkflows/AMR++_standard_wKraken.nf
+++ b/subworkflows/AMR++_standard_wKraken.nf
@@ -1,8 +1,8 @@
-include { FASTQ_QC_WF } from './subworkflows/fastq_information.nf'
-include { FASTQ_TRIM_WF } from './subworkflows/fastq_QC_trimming.nf'
-include { FASTQ_RM_HOST_WF } from './subworkflows/fastq_host_removal.nf' 
-include { FASTQ_RESISTOME_WF } from './subworkflows/fastq_resistome.nf'
-include { FASTQ_KRAKEN_WF } from './subworkflows/fastq_microbiome.nf'
+include { FASTQ_QC_WF } from './fastq_information.nf'
+include { FASTQ_TRIM_WF } from './fastq_QC_trimming.nf'
+include { FASTQ_RM_HOST_WF } from './fastq_host_removal.nf' 
+include { FASTQ_RESISTOME_WF } from './fastq_resistome.nf'
+include { FASTQ_KRAKEN_WF } from './fastq_microbiome.nf'
 
 workflow STANDARD_AMRplusplus_wKraken {
     take: 

--- a/subworkflows/bam_deduped_resistome.nf
+++ b/subworkflows/bam_deduped_resistome.nf
@@ -1,5 +1,5 @@
 // Deduped functions with prefix for name
-include {runresistome_analyzer as runresistome_dedup ; runsnp as runsnp_dedup; resistomeresults as resistomeresults_dedup ; snpresults as snpresults_dedup ; build_dependencies} from '../modules/Resistome/resistome'
+include { snp_coverage_summary ; runresistome_analyzer as runresistome_dedup ; runsnp as runsnp_dedup; resistomeresults as resistomeresults_dedup ; snpresults as snpresults_dedup ; build_dependencies} from '../modules/Resistome/resistome'
 
 
 workflow BAM_DEDUP_RESISTOME_WF {
@@ -25,6 +25,7 @@ workflow BAM_DEDUP_RESISTOME_WF {
         if (params.snp == "Y") {
             runsnp_dedup(bam_ch, resistomeresults_dedup.out.snp_count_matrix) 
             snpresults_dedup(runsnp_dedup.out.snp_counts.collect(),"dedup_AMR")
+            snp_coverage_summary(runsnp_dedup.out.coverage_stats.collect(), "dedup_AMR") 
         }
 }
 

--- a/subworkflows/bam_deduped_resistome.nf
+++ b/subworkflows/bam_deduped_resistome.nf
@@ -18,7 +18,7 @@ workflow BAM_DEDUP_RESISTOME_WF {
             amrsnp =  build_dependencies.out.amrsnp
         }
         else {
-            amrsnp = file("${baseDir}/bin/AmrPlusPlus_SNP/*")
+            amrsnp = files("${baseDir}/bin/AmrPlusPlus_SNP/*")
             resistomeanalyzer = file("${baseDir}/bin/resistome")
             rarefactionanalyzer = file("${baseDir}/bin/rarefaction")
         }

--- a/subworkflows/bam_deduped_resistome.nf
+++ b/subworkflows/bam_deduped_resistome.nf
@@ -1,5 +1,5 @@
 // Deduped functions with prefix for name
-include {runresistome as runresistome_dedup ; runsnp as runsnp_dedup; resistomeresults as resistomeresults_dedup ; snpresults as snpresults_dedup ; build_dependencies} from '../modules/Resistome/resistome'
+include {runresistome_analyzer as runresistome_dedup ; runsnp as runsnp_dedup; resistomeresults as resistomeresults_dedup ; snpresults as snpresults_dedup ; build_dependencies} from '../modules/Resistome/resistome'
 
 
 workflow BAM_DEDUP_RESISTOME_WF {
@@ -13,16 +13,14 @@ workflow BAM_DEDUP_RESISTOME_WF {
         // download resistome and rarefactionanalyzer
         if (file("${baseDir}/bin/AmrPlusPlus_SNP/SNP_Verification.py").isEmpty()){
             build_dependencies()
-            resistomeanalyzer = build_dependencies.out.resistomeanalyzer
             rarefactionanalyzer = build_dependencies.out.rarefactionanalyzer
             amrsnp =  build_dependencies.out.amrsnp
         }
         else {
             amrsnp = files("${baseDir}/bin/AmrPlusPlus_SNP/*")
-            resistomeanalyzer = file("${baseDir}/bin/resistome")
             rarefactionanalyzer = file("${baseDir}/bin/rarefaction")
         }
-        runresistome_dedup(bam_ch,amr, annotation, resistomeanalyzer )
+        runresistome_dedup(bam_ch)
         resistomeresults_dedup(runresistome_dedup.out.resistome_counts.collect(),"dedup_AMR")
         if (params.snp == "Y") {
             runsnp_dedup(bam_ch, resistomeresults_dedup.out.snp_count_matrix) 

--- a/subworkflows/bam_resistome.nf
+++ b/subworkflows/bam_resistome.nf
@@ -1,5 +1,5 @@
 // resistome
-include {coverage_threshold_sweep ; combine_sweep_results ; plot_sweep_dropoff ; plotrarefaction ; runresistome_analyzer ; runsnp ; resistomeresults ; runrarefaction ; build_dependencies ; snpresults ; coverage_threshold_sweep ; plot_sweep_dropoff } from '../modules/Resistome/resistome'
+include {snp_coverage_summary;coverage_threshold_sweep ; combine_sweep_results ; plot_sweep_dropoff ; plotrarefaction ; runresistome_analyzer ; runsnp ; resistomeresults ; runrarefaction ; build_dependencies ; snpresults  } from '../modules/Resistome/resistome'
 
 
 workflow BAM_RESISTOME_WF {
@@ -31,6 +31,7 @@ workflow BAM_RESISTOME_WF {
         if (params.snp == "Y") {
             runsnp(bam_ch, resistomeresults.out.snp_count_matrix)
             snpresults(runsnp.out.snp_counts.collect(), "AMR")
+            snp_coverage_summary(runsnp.out.coverage_stats.collect(), "AMR") 
         }
 }
 

--- a/subworkflows/bam_resistome.nf
+++ b/subworkflows/bam_resistome.nf
@@ -1,5 +1,5 @@
 // resistome
-include {plotrarefaction ; runresistome ; runsnp ; resistomeresults ; runrarefaction ; build_dependencies ; snpresults} from '../modules/Resistome/resistome'
+include {coverage_threshold_sweep ; combine_sweep_results ; plot_sweep_dropoff ; plotrarefaction ; runresistome_analyzer ; runsnp ; resistomeresults ; runrarefaction ; build_dependencies ; snpresults ; coverage_threshold_sweep ; plot_sweep_dropoff } from '../modules/Resistome/resistome'
 
 
 workflow BAM_RESISTOME_WF {
@@ -10,20 +10,18 @@ workflow BAM_RESISTOME_WF {
 
     main:
         // download resistome and rarefactionanalyzer
-        if (file("${baseDir}/bin/AmrPlusPlus_SNP/SNP_Verification.py").isEmpty()){
+        if (!file("${baseDir}/bin/AmrPlusPlus_SNP/SNP_Verification.py").exists()){
             build_dependencies()
-            resistomeanalyzer = build_dependencies.out.resistomeanalyzer
             rarefactionanalyzer = build_dependencies.out.rarefactionanalyzer
             amrsnp =  build_dependencies.out.amrsnp
         }
         else {
-            amrsnp = file("${baseDir}/bin/AmrPlusPlus_SNP/*")
-            resistomeanalyzer = file("${baseDir}/bin/resistome")
+            amrsnp = files("${baseDir}/bin/AmrPlusPlus_SNP/*")
             rarefactionanalyzer = file("${baseDir}/bin/rarefaction")
         }
         // Split sections below for rarefaction and SNP confirmation
-        runresistome(bam_ch,amr, annotation, resistomeanalyzer )
-        resistomeresults(runresistome.out.resistome_counts.collect(), "AMR")
+        runresistome_analyzer(bam_ch)
+        resistomeresults(runresistome_analyzer.out.resistome_counts.collect(), "AMR")
         // Rarefaction
         if (params.rarefaction == "Y") {
             runrarefaction(bam_ch, annotation, amr, rarefactionanalyzer)
@@ -36,4 +34,23 @@ workflow BAM_RESISTOME_WF {
         }
 }
 
+workflow BAM_COVERAGE_SWEEP_WF {
+    take:
+        bam_ch     // tuple(prefix, bam)  -- prefix = BAM basename minus .bam
 
+    main:
+        // 1. One sweep per BAM. Each emits its four <prefix>_*.csv files.
+        coverage_threshold_sweep( bam_ch )
+
+        // 2. Gather EVERY per-sample CSV across ALL samples into one list, then
+        //    combine into the four combined_*.csv matrices. flatten() because each
+        //    sweep task emits a list of 4 files; collect() to wait for all samples.
+        all_sweep_csvs = coverage_threshold_sweep.out.sweep_csvs.flatten().collect()
+        combine_sweep_results( all_sweep_csvs )
+
+        // 3. Plot dropoff summaries from the combined matrices.
+        plot_sweep_dropoff( combine_sweep_results.out.combined )
+
+    emit:
+        combined = combine_sweep_results.out.combined
+}

--- a/subworkflows/bam_resistome_counts.nf
+++ b/subworkflows/bam_resistome_counts.nf
@@ -1,5 +1,5 @@
 // resistome counts and snp verification
-include {plotrarefaction ; runresistome_analyzer ; runsnp ; resistomeresults ; build_dependencies ; snpresults} from '../modules/Resistome/resistome'
+include {snp_coverage_summary; plotrarefaction ; runresistome_analyzer ; runsnp ; resistomeresults ; build_dependencies ; snpresults} from '../modules/Resistome/resistome'
 
 
 workflow BAM_RESISTOME_COUNTS_WF {
@@ -24,6 +24,7 @@ workflow BAM_RESISTOME_COUNTS_WF {
         if (params.snp == "Y") {
             runsnp(bam_ch, resistomeresults.out.snp_count_matrix)
             snpresults(runsnp.out.snp_counts.collect(), "AMR")
+            snp_coverage_summary(runsnp.out.coverage_stats.collect(), "AMR") 
         }
 }
 

--- a/subworkflows/bam_resistome_counts.nf
+++ b/subworkflows/bam_resistome_counts.nf
@@ -21,7 +21,7 @@ workflow BAM_RESISTOME_COUNTS_WF {
         }
         // Run resistome analyzer and count matrix creation
         runresistome(bam_ch,amr, annotation, resistomeanalyzer )
-        resistomeresults(runresistome.out.resistome_counts.collect())
+        resistomeresults(runresistome.out.resistome_counts.collect(), "AMR")
         // Add SNP confirmation
         if (params.snp == "Y") {
             runsnp(bam_ch, resistomeresults.out.snp_count_matrix)

--- a/subworkflows/bam_resistome_counts.nf
+++ b/subworkflows/bam_resistome_counts.nf
@@ -19,7 +19,7 @@ workflow BAM_RESISTOME_COUNTS_WF {
         }
         // Run resistome analyzer and count matrix creation
         runresistome_analyzer(bam_ch )
-        resistomeresults(runresistome.out.resistome_counts.collect(), "AMR")
+        resistomeresults(runresistome_analyzer.out.resistome_counts.collect(), "AMR")
         // Add SNP confirmation
         if (params.snp == "Y") {
             runsnp(bam_ch, resistomeresults.out.snp_count_matrix)

--- a/subworkflows/bam_resistome_counts.nf
+++ b/subworkflows/bam_resistome_counts.nf
@@ -1,5 +1,5 @@
 // resistome counts and snp verification
-include {plotrarefaction ; runresistome ; runsnp ; resistomeresults ; build_dependencies ; snpresults} from '../modules/Resistome/resistome'
+include {plotrarefaction ; runresistome_analyzer ; runsnp ; resistomeresults ; build_dependencies ; snpresults} from '../modules/Resistome/resistome'
 
 
 workflow BAM_RESISTOME_COUNTS_WF {
@@ -12,15 +12,13 @@ workflow BAM_RESISTOME_COUNTS_WF {
         // download resistome and rarefactionanalyzer
         if (file("${baseDir}/bin/AmrPlusPlus_SNP/SNP_Verification.py").isEmpty()){
             build_dependencies()
-            resistomeanalyzer = build_dependencies.out.resistomeanalyzer
             amrsnp =  build_dependencies.out.amrsnp
         }
         else {
             amrsnp = file("${baseDir}/bin/AmrPlusPlus_SNP/*")
-            resistomeanalyzer = file("${baseDir}/bin/resistome")
         }
         // Run resistome analyzer and count matrix creation
-        runresistome(bam_ch,amr, annotation, resistomeanalyzer )
+        runresistome_analyzer(bam_ch )
         resistomeresults(runresistome.out.resistome_counts.collect(), "AMR")
         // Add SNP confirmation
         if (params.snp == "Y") {

--- a/subworkflows/bam_resistome_counts.nf
+++ b/subworkflows/bam_resistome_counts.nf
@@ -10,12 +10,12 @@ workflow BAM_RESISTOME_COUNTS_WF {
 
     main:
         // download resistome and rarefactionanalyzer
-        if (file("${baseDir}/bin/AmrPlusPlus_SNP/SNP_Verification.py").isEmpty()){
+        if (!file("${baseDir}/bin/AmrPlusPlus_SNP/SNP_Verification.py").exists() ){
             build_dependencies()
             amrsnp =  build_dependencies.out.amrsnp
         }
         else {
-            amrsnp = file("${baseDir}/bin/AmrPlusPlus_SNP/*")
+            amrsnp = files("${baseDir}/bin/AmrPlusPlus_SNP/*")
         }
         // Run resistome analyzer and count matrix creation
         runresistome_analyzer(bam_ch )

--- a/subworkflows/fastq_QC_trimming.nf
+++ b/subworkflows/fastq_QC_trimming.nf
@@ -32,7 +32,6 @@ workflow FASTQ_TRIM_WF {
         
 }
 
-
 // Single-end trimming
 workflow FASTQ_TRIM_SE_WF {
   take: read_se_ch

--- a/subworkflows/fastq_align.nf
+++ b/subworkflows/fastq_align.nf
@@ -90,7 +90,6 @@ workflow MERGED_FASTQ_ALIGN_WF {
 
         // Add analysis of deduped counts
         if (params.deduped == "Y"){
-            BAM_DEDUP_RESISTOME_WF(bwa_align.out.bwa_dedup_bam,amr, annotation)
             def bam_deduped_pairs_ch = bwa_merged_align.out.merged_dedup_bam \
                             .mix( bwa_merged_align.out.unmerged_dedup_bam ) \
                             .groupTuple()          // (id, [bam1,bam2])

--- a/subworkflows/fastq_align.nf
+++ b/subworkflows/fastq_align.nf
@@ -17,7 +17,7 @@ workflow FASTQ_ALIGN_WF {
         } else {
             resistomeanalyzer   = file("${baseDir}/bin/resistome")
             rarefactionanalyzer = file("${baseDir}/bin/rarefaction")
-            amrsnp              = file("${baseDir}/bin/AmrPlusPlus_SNP/*")
+            amrsnp              = files("${baseDir}/bin/AmrPlusPlus_SNP/*")
         }
 
         /* ------------ (2) AMR INDEX --------------------------------------- */
@@ -58,7 +58,7 @@ workflow MERGED_FASTQ_ALIGN_WF {
         } else {
             resistomeanalyzer   = file("${baseDir}/bin/resistome")
             rarefactionanalyzer = file("${baseDir}/bin/rarefaction")
-            amrsnp              = file("${baseDir}/bin/AmrPlusPlus_SNP/*")
+            amrsnp              = files("${baseDir}/bin/AmrPlusPlus_SNP/*")
         }
 
         /* ------------ (2) AMR INDEX ------------------------------------- */
@@ -104,7 +104,7 @@ workflow SE_FASTQ_ALIGN_WF {
         } else {
             resistomeanalyzer   = file("${baseDir}/bin/resistome")
             rarefactionanalyzer = file("${baseDir}/bin/rarefaction")
-            amrsnp              = file("${baseDir}/bin/AmrPlusPlus_SNP/*")
+            amrsnp              = files("${baseDir}/bin/AmrPlusPlus_SNP/*")
         }
 
         /* ------------ (2) AMR INDEX --------------------------------------- */

--- a/subworkflows/fastq_align.nf
+++ b/subworkflows/fastq_align.nf
@@ -86,7 +86,19 @@ workflow MERGED_FASTQ_ALIGN_WF {
                             .mix( bwa_merged_align.out.unmerged_bam ) \
                             .groupTuple()          // (id, [bam1,bam2])
 
-        samtools_merge_bams( bam_pairs_ch )
+        samtools_merge_bams( bam_pairs_ch,"standard" )
+
+        // Add analysis of deduped counts
+        if (params.deduped == "Y"){
+            BAM_DEDUP_RESISTOME_WF(bwa_align.out.bwa_dedup_bam,amr, annotation)
+            def bam_deduped_pairs_ch = bwa_merged_align.out.merged_dedup_bam \
+                            .mix( bwa_merged_align.out.unmerged_dedup_bam ) \
+                            .groupTuple()          // (id, [bam1,bam2])
+            samtools_merge_bams_dedup ( bam_pairs_ch,"deduped" )
+
+
+        }
+
 }
 
 workflow SE_FASTQ_ALIGN_WF {

--- a/subworkflows/fastq_align.nf
+++ b/subworkflows/fastq_align.nf
@@ -1,6 +1,6 @@
 // Load modules
 include { index ; bwa_align ; bwa_merged_align ;bwa_align_se ; samtools_dedup_se ; samtools_merge_bams ;  samtools_merge_bams as  samtools_merge_bams_dedup } from '../modules/Alignment/bwa'
-
+include { build_dependencies } from '../modules/Resistome/resistome'
 
 workflow FASTQ_ALIGN_WF {
     take: 

--- a/subworkflows/fastq_align.nf
+++ b/subworkflows/fastq_align.nf
@@ -6,7 +6,6 @@ workflow FASTQ_ALIGN_WF {
     take: 
         read_pairs_ch
         amr
-        annotation
 
     main:
         /* ------------ (1) DEPENDENCIES ---------------------------------- */
@@ -48,7 +47,6 @@ workflow MERGED_FASTQ_ALIGN_WF {
     take:
         merged_reads_ch      // tuple(id, merged_fq, unmerged_fq)
         amr
-        annotation
 
     main:
         /* ------------ (1) DEPENDENCIES ---------------------------------- */
@@ -95,7 +93,6 @@ workflow SE_FASTQ_ALIGN_WF {
     take:
         se_nonhost_ch
         amr
-        annotation
 
     main:
         /* ------------ (1) DEPENDENCIES ---------------------------------- */

--- a/subworkflows/fastq_align.nf
+++ b/subworkflows/fastq_align.nf
@@ -1,7 +1,6 @@
 // Load modules
-include { index ; bwa_align } from '../modules/Alignment/bwa'
+include { index ; bwa_align ; bwa_merged_align ;bwa_align_se ; samtools_dedup_se ; samtools_merge_bams ;  samtools_merge_bams as  samtools_merge_bams_dedup } from '../modules/Alignment/bwa'
 
-import java.nio.file.Paths
 
 workflow FASTQ_ALIGN_WF {
     take: 
@@ -43,3 +42,97 @@ workflow FASTQ_ALIGN_WF {
 }
 
 
+workflow MERGED_FASTQ_ALIGN_WF {
+
+    /* ------------ INPUTS -------------------------------------------------- */
+    take:
+        merged_reads_ch      // tuple(id, merged_fq, unmerged_fq)
+        amr
+        annotation
+
+    main:
+        /* ------------ (1) DEPENDENCIES ---------------------------------- */
+        if ( !file("${baseDir}/bin/AmrPlusPlus_SNP/SNP_Verification.py").exists() ) {
+            build_dependencies()
+            resistomeanalyzer   = build_dependencies.out.resistomeanalyzer
+            rarefactionanalyzer = build_dependencies.out.rarefactionanalyzer
+            amrsnp              = build_dependencies.out.amrsnp
+        } else {
+            resistomeanalyzer   = file("${baseDir}/bin/resistome")
+            rarefactionanalyzer = file("${baseDir}/bin/rarefaction")
+            amrsnp              = file("${baseDir}/bin/AmrPlusPlus_SNP/*")
+        }
+
+        /* ------------ (2) AMR INDEX ------------------------------------- */
+        if (params.amr_index) {
+            amr_index_files = Channel
+                .fromPath(params.amr_index, glob: true)
+                .ifEmpty { error "No files match --amr_index '${params.amr_index}'" }
+                .collect()
+                .map { files ->
+                    if (files.size() < 7) {
+                        error "Expected 7 AMR index files, found ${files.size()}. Please provide all 7 files, including the AMR database fasta file. Remember to use * in your path."
+                    }
+                    files.sort()
+                }
+        } else {
+            index(amr)
+            amr_index_files = index.out
+        }
+
+        /* ------------ (3)  ALIGN READS --------------------------------------- */
+        bwa_merged_align( amr_index_files, merged_reads_ch )
+
+        /* ------------ (4)  MERGE BAMs ---------------------------------------- */
+        def bam_pairs_ch = bwa_merged_align.out.merged_bam \
+                            .mix( bwa_merged_align.out.unmerged_bam ) \
+                            .groupTuple()          // (id, [bam1,bam2])
+
+        samtools_merge_bams( bam_pairs_ch )
+}
+
+workflow SE_FASTQ_ALIGN_WF {
+    take:
+        se_nonhost_ch
+        amr
+        annotation
+
+    main:
+        /* ------------ (1) DEPENDENCIES ---------------------------------- */
+        if ( !file("${baseDir}/bin/AmrPlusPlus_SNP/SNP_Verification.py").exists() ) {
+            build_dependencies()
+            resistomeanalyzer   = build_dependencies.out.resistomeanalyzer
+            rarefactionanalyzer = build_dependencies.out.rarefactionanalyzer
+            amrsnp              = build_dependencies.out.amrsnp
+        } else {
+            resistomeanalyzer   = file("${baseDir}/bin/resistome")
+            rarefactionanalyzer = file("${baseDir}/bin/rarefaction")
+            amrsnp              = file("${baseDir}/bin/AmrPlusPlus_SNP/*")
+        }
+
+        /* ------------ (2) AMR INDEX --------------------------------------- */
+        if (params.amr_index) {
+            amr_index_files = Channel
+                .fromPath(params.amr_index, glob: true)
+                .ifEmpty { error "No files match --amr_index '${params.amr_index}'" }
+                .collect()
+                .map { files ->
+                    if (files.size() < 7) {
+                        error "Expected 7 AMR index files, found ${files.size()}. Please provide all 7 files, including the AMR database fasta file. Remember to use * in your path."
+                    }
+                    files.sort()
+                }
+        } else {
+            index(amr)
+            amr_index_files = index.out
+        }
+
+        /* ------------ (3) ALIGN SE → coordinate-sorted BAM + index --------- */
+        bwa_align_se( amr_index_files, se_nonhost_ch )
+
+        // Optional de-dup using samtools markdup
+        samtools_dedup_se( bwa_align_se.out.bwa_bam )
+        def bam_for_resistome = (params.deduped == 'Y') \
+            ? samtools_dedup_se.out.dedup_bam \
+            : bwa_align_se.out.bwa_bam
+}

--- a/subworkflows/fastq_align.nf
+++ b/subworkflows/fastq_align.nf
@@ -7,27 +7,38 @@ workflow FASTQ_ALIGN_WF {
     take: 
         read_pairs_ch
         amr
+        annotation
 
     main:
-        // Define amr_index_files variable
-        if (params.amr_index == null) {
+        /* ------------ (1) DEPENDENCIES ---------------------------------- */
+        if ( !file("${baseDir}/bin/AmrPlusPlus_SNP/SNP_Verification.py").exists() ) {
+            build_dependencies()
+            resistomeanalyzer   = build_dependencies.out.resistomeanalyzer
+            rarefactionanalyzer = build_dependencies.out.rarefactionanalyzer
+            amrsnp              = build_dependencies.out.amrsnp
+        } else {
+            resistomeanalyzer   = file("${baseDir}/bin/resistome")
+            rarefactionanalyzer = file("${baseDir}/bin/rarefaction")
+            amrsnp              = file("${baseDir}/bin/AmrPlusPlus_SNP/*")
+        }
+
+        /* ------------ (2) AMR INDEX --------------------------------------- */
+        if (params.amr_index) {
+            amr_index_files = Channel
+                .fromPath(params.amr_index, glob: true)
+                .ifEmpty { error "No files match --amr_index '${params.amr_index}'" }
+                .collect()
+                .map { files ->
+                    if (files.size() < 7) {
+                        error "Expected 7 AMR index files, found ${files.size()}. Please provide all 7 files, including the AMR database fasta file. Remember to use * in your path."
+                    }
+                    files.sort()
+                }
+        } else {
             index(amr)
             amr_index_files = index.out
-        } else {
-            amr_index_files = Channel
-                .fromPath(Paths.get(params.amr_index))
-                .map { file(it.toString()) }
-                .filter { file(it).exists() }
-                .toList()
-                .map { files ->
-                    if (files.size() < 6) {
-                        error "Expected 6 AMR index files, found ${files.size()}. Please provide all 6 files, including the AMR database fasta file. Remember to use * in your path."
-                    } else {
-                        files.sort()
-                    }
-                }
-         }        
-        // AMR alignment
+        }     
+        /* ------------ (3) AMR ALIGNMENT ----------------------------------- */
         bwa_align(amr_index_files, read_pairs_ch )
 }
 

--- a/subworkflows/fastq_deduplicate.nf
+++ b/subworkflows/fastq_deduplicate.nf
@@ -1,0 +1,18 @@
+// Load modules
+include { DeduplicateReadsSeqkit} from '../modules/QC/dedup'
+
+
+
+// Single-end trimming
+workflow FASTQ_DEDUP_SE_WF {
+  take: read_se_ch
+  main:
+    DeduplicateReadsSeqkit(read_se_ch)
+
+  emit:
+    deduped_reads = DeduplicateReadsSeqkit.out.dedup_fq
+
+}
+
+
+

--- a/subworkflows/fastq_deduplicate.nf
+++ b/subworkflows/fastq_deduplicate.nf
@@ -1,9 +1,11 @@
 // Load modules
 include { DeduplicateReadsSeqkit} from '../modules/QC/dedup'
+include { PE_DeduplicateReadsSeqkit} from '../modules/QC/dedup'
+include { PE_DeduplicateMergedReadsSeqkit} from '../modules/QC/dedup'
 
 
 
-// Single-end trimming
+// Single-end deduplication
 workflow FASTQ_DEDUP_SE_WF {
   take: read_se_ch
   main:
@@ -14,5 +16,26 @@ workflow FASTQ_DEDUP_SE_WF {
 
 }
 
+// Paired end trimming
+workflow FASTQ_DEDUP_PE_WF {
+  take: fastq_files
+  main:
+    PE_DeduplicateReadsSeqkit(fastq_files)
+
+  emit:
+    deduped_reads = PE_DeduplicateReadsSeqkit.out.dedup_pe_fq
+
+}
+
+// Paired end trimming
+workflow FASTQ_DEDUP_MERGED_WF {
+  take: fastq_files
+  main:
+    PE_DeduplicateMergedReadsSeqkit(fastq_files)
+
+  emit:
+    deduped_merged_reads = PE_DeduplicateMergedReadsSeqkit.out.dedup_merged_fq
+
+}
 
 

--- a/subworkflows/fastq_deduplicate.nf
+++ b/subworkflows/fastq_deduplicate.nf
@@ -1,5 +1,5 @@
 // Load modules
-include { DeduplicateReadsSeqkit} from '../modules/QC/dedup'
+include { SE_DeduplicateReadsSeqkit} from '../modules/QC/dedup'
 include { PE_DeduplicateReadsSeqkit} from '../modules/QC/dedup'
 include { PE_DeduplicateMergedReadsSeqkit} from '../modules/QC/dedup'
 
@@ -9,10 +9,10 @@ include { PE_DeduplicateMergedReadsSeqkit} from '../modules/QC/dedup'
 workflow FASTQ_DEDUP_SE_WF {
   take: read_se_ch
   main:
-    DeduplicateReadsSeqkit(read_se_ch)
+    SE_DeduplicateReadsSeqkit(read_se_ch)
 
   emit:
-    deduped_reads = DeduplicateReadsSeqkit.out.dedup_fq
+    deduped_reads = SE_DeduplicateReadsSeqkit.out.dedup_fq
 
 }
 

--- a/subworkflows/fastq_deduplicate.nf
+++ b/subworkflows/fastq_deduplicate.nf
@@ -1,18 +1,19 @@
+// Switched to runnning Clumpify by default. to switch back, highlight everything under this 
+// and use ctrl+F and replace to switch between "Seqkit" and "Clumpify"
+
 // Load modules
-include { SE_DeduplicateReadsSeqkit} from '../modules/QC/dedup'
-include { PE_DeduplicateReadsSeqkit} from '../modules/QC/dedup'
-include { PE_DeduplicateMergedReadsSeqkit} from '../modules/QC/dedup'
-
-
+include { SE_DeduplicateReadsClumpify} from '../modules/QC/dedup'
+include { PE_DeduplicateReadsClumpify} from '../modules/QC/dedup'
+include { PE_DeduplicateMergedReadsClumpify} from '../modules/QC/dedup'
 
 // Single-end deduplication
 workflow FASTQ_DEDUP_SE_WF {
   take: read_se_ch
   main:
-    SE_DeduplicateReadsSeqkit(read_se_ch)
+    SE_DeduplicateReadsClumpify(read_se_ch)
 
   emit:
-    deduped_reads = SE_DeduplicateReadsSeqkit.out.dedup_fq
+    deduped_reads = SE_DeduplicateReadsClumpify.out.dedup_fq
 
 }
 
@@ -20,10 +21,10 @@ workflow FASTQ_DEDUP_SE_WF {
 workflow FASTQ_DEDUP_PE_WF {
   take: fastq_files
   main:
-    PE_DeduplicateReadsSeqkit(fastq_files)
+    PE_DeduplicateReadsClumpify(fastq_files)
 
   emit:
-    deduped_reads = PE_DeduplicateReadsSeqkit.out.dedup_pe_fq
+    deduped_reads = PE_DeduplicateReadsClumpify.out.dedup_pe_fq
 
 }
 
@@ -31,10 +32,10 @@ workflow FASTQ_DEDUP_PE_WF {
 workflow FASTQ_DEDUP_MERGED_WF {
   take: fastq_files
   main:
-    PE_DeduplicateMergedReadsSeqkit(fastq_files)
+    PE_DeduplicateMergedReadsClumpify(fastq_files)
 
   emit:
-    deduped_merged_reads = PE_DeduplicateMergedReadsSeqkit.out.dedup_merged_fq
+    deduped_merged_reads = PE_DeduplicateMergedReadsClumpify.out.dedup_merged_fq
 
 }
 

--- a/subworkflows/fastq_deduplicate.nf
+++ b/subworkflows/fastq_deduplicate.nf
@@ -28,7 +28,7 @@ workflow FASTQ_DEDUP_PE_WF {
 
 }
 
-// Paired end trimming
+// Merged read trimming
 workflow FASTQ_DEDUP_MERGED_WF {
   take: fastq_files
   main:

--- a/subworkflows/fastq_host_removal.nf
+++ b/subworkflows/fastq_host_removal.nf
@@ -5,9 +5,6 @@ include { SeqkitReadCounts } from '../modules/QC/merge'
 include { bwa_rm_contaminant_se } from '../modules/Alignment/bwa'
 
 
-
-import java.nio.file.Paths
-
 //  Host removal for paired reads
 workflow FASTQ_RM_HOST_WF {
     take: 
@@ -15,24 +12,22 @@ workflow FASTQ_RM_HOST_WF {
         read_pairs_ch
     main:
         // Define reference_index variable
-        if (params.host_index == null) {
-            index(hostfasta)
-            reference_index_files = index.out
-        } else {
+        if (params.host_index) {
             reference_index_files = Channel
-                .fromPath(Paths.get(params.host_index))
-                .map { file(it.toString()) }
-                .filter { file(it).exists() }
+                .fromPath(params.host_index, glob: true)
+                .ifEmpty { error "No files match --host_index '${params.host_index}'" }
                 .toList()
                 .map { files ->
                     if (files.size() < 6) {
                         error "Expected 6 host index files, found ${files.size()}. Please provide all 6 files, including the host fasta file. Remember to use * in your path."
-                    } else {
-                        files.sort()
                     }
+                    files.sort()
                 }
-         }    
-        bwa_rm_contaminant_fq(reference_index_files, read_pairs_ch )
+        } else {
+            index(hostfasta)
+            reference_index_ch = index.out
+        }   
+        bwa_rm_contaminant_fq(reference_index_ch, read_pairs_ch )
         HostRemovalStats(bwa_rm_contaminant_fq.out.host_rm_stats.collect())
     emit:
         nonhost_reads = bwa_rm_contaminant_fq.out.nonhost_reads  
@@ -45,15 +40,21 @@ workflow MERGED_FASTQ_RM_HOST_WF {
 
     main:
         /* 1 ─ build / load BWA index -------------------------------------- */
-        def reference_index_ch =
-            params.host_index
-            ? Channel.fromPath( params.host_index , glob:true )
-                    .ifEmpty { error "No files match --host_index '${params.host_index}'" }
-                    .toList()
-                    .map { it.sort() }               // bundle 6 index files
-            : { index( hostfasta ); index.out }()     // call in a closure
-
-
+        if (params.host_index) {
+            reference_index_ch = Channel
+                .fromPath(params.host_index, glob: true)
+                .ifEmpty { error "No files match --host_index '${params.host_index}'" }
+                .toList()
+                .map { files ->
+                    if (files.size() < 6) {
+                        error "Expected 6 host index files, found ${files.size()}. Please provide all 6 files, including the host fasta file. Remember to use * in your path."
+                    }
+                    files.sort()
+                }
+        } else {
+            index(hostfasta)
+            reference_index_ch = index.out
+        }
         /* 2 ─ host-removal -------------------------------------------------- */
         bwa_rm_contaminant_merged_fq( reference_index_ch , merged_reads_ch )
         
@@ -84,14 +85,22 @@ workflow FASTQ_RM_HOST_SE_WF {
         se_reads_ch   // tuple(sample_id, read.fastq[.gz])
 
     main:
-        def host_index_ch = params.host_index
-            ? Channel.fromPath(params.host_index, glob:true)
-                     .ifEmpty { error "No files match --host_index '${params.host_index}'" }
-                     .toList()
-                     .map { it.sort() }
-            : { index(hostfasta); index.out }()
-
-        bwa_rm_contaminant_se( host_index_ch, se_reads_ch )
+        if (params.host_index) {
+            host_index_ch = Channel
+                .fromPath(params.host_index, glob: true)
+                .ifEmpty { error "No files match --host_index '${params.host_index}'" }
+                .toList()
+                .map { files ->
+                    if (files.size() < 6) {
+                        error "Expected 6 host index files, found ${files.size()}. Please provide all 6 files, including the host fasta file. Remember to use * in your path."
+                    }
+                    files.sort()
+                }
+        } else {
+            index(hostfasta)
+            host_index_ch = index.out
+        }
+        bwa_rm_contaminant_se( reference_index_ch, se_reads_ch )
         HostRemovalStats( bwa_rm_contaminant_se.out.host_rm_stats.collect() )
 
     emit:

--- a/subworkflows/fastq_host_removal.nf
+++ b/subworkflows/fastq_host_removal.nf
@@ -86,7 +86,7 @@ workflow FASTQ_RM_HOST_SE_WF {
 
     main:
         if (params.host_index) {
-            host_index_ch = Channel
+            reference_index_ch = Channel
                 .fromPath(params.host_index, glob: true)
                 .ifEmpty { error "No files match --host_index '${params.host_index}'" }
                 .toList()
@@ -98,7 +98,7 @@ workflow FASTQ_RM_HOST_SE_WF {
                 }
         } else {
             index(hostfasta)
-            host_index_ch = index.out
+            reference_index_ch = index.out
         }
         bwa_rm_contaminant_se( reference_index_ch, se_reads_ch )
         HostRemovalStats( bwa_rm_contaminant_se.out.host_rm_stats.collect() )

--- a/subworkflows/fastq_merging.nf
+++ b/subworkflows/fastq_merging.nf
@@ -1,8 +1,6 @@
 // Load modules
 include {MergeReadsFlash } from '../modules/QC/merge'
 
-import java.nio.file.Paths
-
 workflow FASTQ_MERGE_WF {
     take: 
         read_pairs_ch

--- a/subworkflows/fastq_resistome.nf
+++ b/subworkflows/fastq_resistome.nf
@@ -7,7 +7,6 @@ include { plotrarefaction ; runresistome ; runsnp ; resistomeresults ; runrarefa
 // Deduped resistome
 include { BAM_DEDUP_RESISTOME_WF } from '../subworkflows/bam_deduped_resistome.nf'
 
-import java.nio.file.Paths
 
 workflow FASTQ_RESISTOME_WF {
     take: 
@@ -16,37 +15,35 @@ workflow FASTQ_RESISTOME_WF {
         annotation
 
     main:
-        // download resistome and rarefactionanalyzer
-        if (file("${baseDir}/bin/AmrPlusPlus_SNP/SNP_Verification.py").isEmpty()){
+        /* ------------ (1) DEPENDENCIES ---------------------------------- */
+        if ( !file("${baseDir}/bin/AmrPlusPlus_SNP/SNP_Verification.py").exists() ) {
             build_dependencies()
-            resistomeanalyzer = build_dependencies.out.resistomeanalyzer
+            resistomeanalyzer   = build_dependencies.out.resistomeanalyzer
             rarefactionanalyzer = build_dependencies.out.rarefactionanalyzer
-            amrsnp =  build_dependencies.out.amrsnp
-        }
-        else {
-            amrsnp = file("${baseDir}/bin/AmrPlusPlus_SNP/*")
-            resistomeanalyzer = file("${baseDir}/bin/resistome")
-            rarefactionanalyzer = file("${baseDir}/bin/rarefaction")
-        }
-        // Define amr_index_files variable
-        if (params.amr_index == null) {
-            index(amr)
-            amr_index_files = index.out
+            amrsnp              = build_dependencies.out.amrsnp
         } else {
+            resistomeanalyzer   = file("${baseDir}/bin/resistome")
+            rarefactionanalyzer = file("${baseDir}/bin/rarefaction")
+            amrsnp              = file("${baseDir}/bin/AmrPlusPlus_SNP/*")
+        }
+
+        /* ------------ (2) AMR INDEX --------------------------------------- */
+        if (params.amr_index) {
             amr_index_files = Channel
-                .fromPath(Paths.get(params.amr_index))
-                .map { file(it.toString()) }
-                .filter { file(it).exists() }
-                .toList()
+                .fromPath(params.amr_index, glob: true)
+                .ifEmpty { error "No files match --amr_index '${params.amr_index}'" }
+                .collect()
                 .map { files ->
                     if (files.size() < 7) {
                         error "Expected 7 AMR index files, found ${files.size()}. Please provide all 7 files, including the AMR database fasta file. Remember to use * in your path."
-                    } else {
-                        files.sort()
                     }
+                    files.sort()
                 }
-         }        
-        // AMR alignment
+        } else {
+            index(amr)
+            amr_index_files = index.out
+        }     
+        /* ------------ (3) AMR ALIGNMENT ----------------------------------- */
         bwa_align(amr_index_files, read_pairs_ch )
         // Split sections below for standard and dedup_ed results
         runresistome(bwa_align.out.bwa_bam,amr, annotation, resistomeanalyzer )
@@ -81,9 +78,8 @@ workflow MERGED_FASTQ_RESISTOME_WF {
         annotation
 
     main:
-        /* ------------ (1)  DEPENDENCIES -------------------------------------- */
-
-        if( !new File("${baseDir}/bin/AmrPlusPlus_SNP/SNP_Verification.py").exists() ) {
+        /* ------------ (1) DEPENDENCIES ---------------------------------- */
+        if ( !file("${baseDir}/bin/AmrPlusPlus_SNP/SNP_Verification.py").exists() ) {
             build_dependencies()
             resistomeanalyzer   = build_dependencies.out.resistomeanalyzer
             rarefactionanalyzer = build_dependencies.out.rarefactionanalyzer
@@ -93,32 +89,22 @@ workflow MERGED_FASTQ_RESISTOME_WF {
             rarefactionanalyzer = file("${baseDir}/bin/rarefaction")
             amrsnp              = file("${baseDir}/bin/AmrPlusPlus_SNP/*")
         }
-        /* ------------ (2)  AMR INDEX ----------------------------------------- */
-        // declare the channel handle first
 
-        if( params.amr_index == null ) {
-
-            // run the indexing process you already defined
-            index( amr )
-            amr_index_files = index.out          // <-- channel of 6 files
-
-        } else {
-
-            // read files matching the user-supplied pattern
+        /* ------------ (2) AMR INDEX ------------------------------------- */
+        if (params.amr_index) {
             amr_index_files = Channel
-                .fromPath( params.amr_index )    // emit each path
-                .ifEmpty {
-                    error "No files matched '${params.amr_index}'. " +
-                        "Did you forget the * wildcard?"
-                }
-                .collect()                       // gather into a single list
+                .fromPath(params.amr_index, glob: true)
+                .ifEmpty { error "No files match --amr_index '${params.amr_index}'" }
+                .collect()
                 .map { files ->
-                    if( files.size() != 7 )
-                        throw new RuntimeException(
-                            "Expected 7 AMR index files, found ${files.size()}. Please provide all 7 files, including the AMR database fasta file. Remember to use * in your path."
-                        )
-                    files.sort()                 // ensure deterministic order
+                    if (files.size() < 7) {
+                        error "Expected 7 AMR index files, found ${files.size()}. Please provide all 7 files, including the AMR database fasta file. Remember to use * in your path."
+                    }
+                    files.sort()
                 }
+        } else {
+            index(amr)
+            amr_index_files = index.out
         }
 
         /* ------------ (3)  ALIGN READS --------------------------------------- */
@@ -164,18 +150,36 @@ workflow FASTQ_RESISTOME_SE_WF {
         annotation
 
     main:
-        if( !file("${baseDir}/bin/AmrPlusPlus_SNP/SNP_Verification.py").exists() ) {
+        /* ------------ (1) DEPENDENCIES ---------------------------------- */
+        if ( !file("${baseDir}/bin/AmrPlusPlus_SNP/SNP_Verification.py").exists() ) {
             build_dependencies()
+            resistomeanalyzer   = build_dependencies.out.resistomeanalyzer
+            rarefactionanalyzer = build_dependencies.out.rarefactionanalyzer
+            amrsnp              = build_dependencies.out.amrsnp
+        } else {
+            resistomeanalyzer   = file("${baseDir}/bin/resistome")
+            rarefactionanalyzer = file("${baseDir}/bin/rarefaction")
+            amrsnp              = file("${baseDir}/bin/AmrPlusPlus_SNP/*")
         }
 
-        def amr_index_files = params.amr_index
-            ? Channel.fromPath(params.amr_index)
-                     .ifEmpty { error "No files matched --amr_index '${params.amr_index}'" }
-                     .collect()
-                     .map { it.sort() }
-            : { index(amr); index.out }()
+        /* ------------ (2) AMR INDEX --------------------------------------- */
+        if (params.amr_index) {
+            amr_index_files = Channel
+                .fromPath(params.amr_index, glob: true)
+                .ifEmpty { error "No files match --amr_index '${params.amr_index}'" }
+                .collect()
+                .map { files ->
+                    if (files.size() < 7) {
+                        error "Expected 7 AMR index files, found ${files.size()}. Please provide all 7 files, including the AMR database fasta file. Remember to use * in your path."
+                    }
+                    files.sort()
+                }
+        } else {
+            index(amr)
+            amr_index_files = index.out
+        }
 
-        // Align SE → coordinate-sorted BAM + index
+        /* ------------ (3) ALIGN SE → coordinate-sorted BAM + index --------- */
         bwa_align_se( amr_index_files, se_nonhost_ch )
 
         // Optional de-dup using samtools markdup
@@ -186,9 +190,11 @@ workflow FASTQ_RESISTOME_SE_WF {
 
         runresistome   ( bam_for_resistome, amr, annotation, file("${baseDir}/bin/resistome") )
         resistomeresults( runresistome.out.resistome_counts.collect(), "AMR" )
-
-        runrarefaction ( bam_for_resistome, annotation, amr, file("${baseDir}/bin/rarefaction") )
-        plotrarefaction( runrarefaction.out.rarefaction.collect(), "AMR" )
+        
+        if (params.rarefaction == "Y") {
+            runrarefaction ( bam_for_resistome, annotation, amr, rarefactionanalyzer )
+            plotrarefaction( runrarefaction.out.rarefaction.collect(), "AMR" )
+        }
 
         if( params.snp == 'Y' ) {
             runsnp    ( bam_for_resistome, resistomeresults.out.snp_count_matrix )

--- a/subworkflows/fastq_resistome.nf
+++ b/subworkflows/fastq_resistome.nf
@@ -2,7 +2,7 @@
 include { index ; bwa_align ; bwa_merged_align ;bwa_align_se ; samtools_dedup_se ; samtools_merge_bams ;  samtools_merge_bams as  samtools_merge_bams_dedup} from '../modules/Alignment/bwa'
 
 // resistome
-include { plotrarefaction ; runresistome ; runsnp ; resistomeresults ; runrarefaction ; build_dependencies ; snpresults} from '../modules/Resistome/resistome'
+include { plotrarefaction ; runresistome_analyzer ; runsnp ; resistomeresults ; runrarefaction ; build_dependencies ; snpresults} from '../modules/Resistome/resistome'
 
 // Deduped resistome
 include { BAM_DEDUP_RESISTOME_WF } from '../subworkflows/bam_deduped_resistome.nf'
@@ -18,11 +18,9 @@ workflow FASTQ_RESISTOME_WF {
         /* ------------ (1) DEPENDENCIES ---------------------------------- */
         if ( !file("${baseDir}/bin/AmrPlusPlus_SNP/SNP_Verification.py").exists() ) {
             build_dependencies()
-            resistomeanalyzer   = build_dependencies.out.resistomeanalyzer
             rarefactionanalyzer = build_dependencies.out.rarefactionanalyzer
             amrsnp              = build_dependencies.out.amrsnp
         } else {
-            resistomeanalyzer   = file("${baseDir}/bin/resistome")
             rarefactionanalyzer = file("${baseDir}/bin/rarefaction")
             amrsnp              = files("${baseDir}/bin/AmrPlusPlus_SNP/*")
         }
@@ -46,8 +44,8 @@ workflow FASTQ_RESISTOME_WF {
         /* ------------ (3) AMR ALIGNMENT ----------------------------------- */
         bwa_align(amr_index_files, read_pairs_ch )
         // Split sections below for standard and dedup_ed results
-        runresistome(bwa_align.out.bwa_bam,amr, annotation, resistomeanalyzer )
-        resistomeresults(runresistome.out.resistome_counts.collect(), "AMR")
+        runresistome_analyzer(bwa_align.out.bwa_bam)
+        resistomeresults(runresistome_analyzer.out.resistome_counts.collect(), "AMR")
         if (params.rarefaction == "Y") {
             runrarefaction(bwa_align.out.bwa_bam, annotation, amr, rarefactionanalyzer)
             plotrarefaction(runrarefaction.out.rarefaction.collect(), "AMR")
@@ -81,11 +79,9 @@ workflow MERGED_FASTQ_RESISTOME_WF {
         /* ------------ (1) DEPENDENCIES ---------------------------------- */
         if ( !file("${baseDir}/bin/AmrPlusPlus_SNP/SNP_Verification.py").exists() ) {
             build_dependencies()
-            resistomeanalyzer   = build_dependencies.out.resistomeanalyzer
             rarefactionanalyzer = build_dependencies.out.rarefactionanalyzer
             amrsnp              = build_dependencies.out.amrsnp
         } else {
-            resistomeanalyzer   = file("${baseDir}/bin/resistome")
             rarefactionanalyzer = file("${baseDir}/bin/rarefaction")
             amrsnp              = files("${baseDir}/bin/AmrPlusPlus_SNP/*")
         }
@@ -115,12 +111,12 @@ workflow MERGED_FASTQ_RESISTOME_WF {
                             .mix( bwa_merged_align.out.unmerged_bam ) \
                             .groupTuple()          // (id, [bam1,bam2])
 
-        samtools_merge_bams( bam_pairs_ch )
+        samtools_merge_bams( bam_pairs_ch ,"")
         def combo_bam_ch = samtools_merge_bams.out.combo_bam
 
         /* ------------ (5)  RESISTOME / RAREFACTION --------------------------- */
-        runresistome   ( combo_bam_ch, amr, annotation, resistomeanalyzer )
-        resistomeresults( runresistome.out.resistome_counts.collect() , "AMR")
+        runresistome_analyzer   ( combo_bam_ch )
+        resistomeresults( runresistome_analyzer.out.resistome_counts.collect() , "AMR")
 
         runrarefaction ( combo_bam_ch, annotation, amr, rarefactionanalyzer )
         plotrarefaction( runrarefaction.out.rarefaction.collect(), "AMR" )
@@ -136,7 +132,7 @@ workflow MERGED_FASTQ_RESISTOME_WF {
             def dedup_pairs_ch = bwa_merged_align.out.merged_dedup_bam \
                                     .mix( bwa_merged_align.out.unmerged_dedup_bam ) \
                                     .groupTuple()
-            samtools_merge_bams_dedup( dedup_pairs_ch )
+            samtools_merge_bams_dedup( dedup_pairs_ch , "Deduped")
             BAM_DEDUP_RESISTOME_WF( samtools_merge_bams_dedup.out.combo_bam,
                                     amr, annotation )
         }
@@ -153,11 +149,9 @@ workflow FASTQ_RESISTOME_SE_WF {
         /* ------------ (1) DEPENDENCIES ---------------------------------- */
         if ( !file("${baseDir}/bin/AmrPlusPlus_SNP/SNP_Verification.py").exists() ) {
             build_dependencies()
-            resistomeanalyzer   = build_dependencies.out.resistomeanalyzer
             rarefactionanalyzer = build_dependencies.out.rarefactionanalyzer
             amrsnp              = build_dependencies.out.amrsnp
         } else {
-            resistomeanalyzer   = file("${baseDir}/bin/resistome")
             rarefactionanalyzer = file("${baseDir}/bin/rarefaction")
             amrsnp              = files("${baseDir}/bin/AmrPlusPlus_SNP/*")
         }
@@ -188,8 +182,8 @@ workflow FASTQ_RESISTOME_SE_WF {
             ? samtools_dedup_se.out.dedup_bam \
             : bwa_align_se.out.bwa_bam
 
-        runresistome   ( bam_for_resistome, amr, annotation, resistomeanalyzer )
-        resistomeresults( runresistome.out.resistome_counts.collect(), "AMR" )
+        runresistome_analyzer   ( bam_for_resistome )
+        resistomeresults( runresistome_analyzer.out.resistome_counts.collect(), "AMR" )
         
         if (params.rarefaction == "Y") {
             runrarefaction ( bam_for_resistome, annotation, amr, rarefactionanalyzer )

--- a/subworkflows/fastq_resistome.nf
+++ b/subworkflows/fastq_resistome.nf
@@ -24,7 +24,7 @@ workflow FASTQ_RESISTOME_WF {
         } else {
             resistomeanalyzer   = file("${baseDir}/bin/resistome")
             rarefactionanalyzer = file("${baseDir}/bin/rarefaction")
-            amrsnp              = file("${baseDir}/bin/AmrPlusPlus_SNP/*")
+            amrsnp              = files("${baseDir}/bin/AmrPlusPlus_SNP/*")
         }
 
         /* ------------ (2) AMR INDEX --------------------------------------- */
@@ -87,7 +87,7 @@ workflow MERGED_FASTQ_RESISTOME_WF {
         } else {
             resistomeanalyzer   = file("${baseDir}/bin/resistome")
             rarefactionanalyzer = file("${baseDir}/bin/rarefaction")
-            amrsnp              = file("${baseDir}/bin/AmrPlusPlus_SNP/*")
+            amrsnp              = files("${baseDir}/bin/AmrPlusPlus_SNP/*")
         }
 
         /* ------------ (2) AMR INDEX ------------------------------------- */
@@ -159,7 +159,7 @@ workflow FASTQ_RESISTOME_SE_WF {
         } else {
             resistomeanalyzer   = file("${baseDir}/bin/resistome")
             rarefactionanalyzer = file("${baseDir}/bin/rarefaction")
-            amrsnp              = file("${baseDir}/bin/AmrPlusPlus_SNP/*")
+            amrsnp              = files("${baseDir}/bin/AmrPlusPlus_SNP/*")
         }
 
         /* ------------ (2) AMR INDEX --------------------------------------- */

--- a/subworkflows/fastq_resistome.nf
+++ b/subworkflows/fastq_resistome.nf
@@ -188,7 +188,7 @@ workflow FASTQ_RESISTOME_SE_WF {
             ? samtools_dedup_se.out.dedup_bam \
             : bwa_align_se.out.bwa_bam
 
-        runresistome   ( bam_for_resistome, amr, annotation, file("${baseDir}/bin/resistome") )
+        runresistome   ( bam_for_resistome, amr, annotation, resistomeanalyzer )
         resistomeresults( runresistome.out.resistome_counts.collect(), "AMR" )
         
         if (params.rarefaction == "Y") {

--- a/subworkflows/fastq_resistome.nf
+++ b/subworkflows/fastq_resistome.nf
@@ -2,7 +2,7 @@
 include { index ; bwa_align ; bwa_merged_align ;bwa_align_se ; samtools_dedup_se ; samtools_merge_bams ;  samtools_merge_bams as  samtools_merge_bams_dedup} from '../modules/Alignment/bwa'
 
 // resistome
-include { plotrarefaction ; runresistome_analyzer ; runsnp ; resistomeresults ; runrarefaction ; build_dependencies ; snpresults} from '../modules/Resistome/resistome'
+include { snp_coverage_summary ; plotrarefaction ; runresistome_analyzer ; runsnp ; resistomeresults ; runrarefaction ; build_dependencies ; snpresults} from '../modules/Resistome/resistome'
 
 // Deduped resistome
 include { BAM_DEDUP_RESISTOME_WF } from '../subworkflows/bam_deduped_resistome.nf'
@@ -54,6 +54,7 @@ workflow FASTQ_RESISTOME_WF {
         if (params.snp == "Y") {
             runsnp(bwa_align.out.bwa_bam, resistomeresults.out.snp_count_matrix)
             snpresults(runsnp.out.snp_counts.collect() ,"AMR" )
+            snp_coverage_summary(runsnp.out.coverage_stats.collect(), "AMR") 
         }
         // Add analysis of deduped counts
         if (params.deduped == "Y"){
@@ -125,6 +126,7 @@ workflow MERGED_FASTQ_RESISTOME_WF {
         if( params.snp == 'Y' ) {
             runsnp    ( combo_bam_ch, resistomeresults.out.snp_count_matrix )
             snpresults( runsnp.out.snp_counts.collect() ,"AMR")
+            snp_coverage_summary(runsnp.out.coverage_stats.collect(), "AMR") 
         }
 
         /* ------------ (7)  DEDUP (optional) ---------------------------------- */
@@ -193,5 +195,6 @@ workflow FASTQ_RESISTOME_SE_WF {
         if( params.snp == 'Y' ) {
             runsnp    ( bam_for_resistome, resistomeresults.out.snp_count_matrix )
             snpresults( runsnp.out.snp_counts.collect(), "AMR" )
+            snp_coverage_summary(runsnp.out.coverage_stats.collect(), "AMR") 
         }
 }


### PR DESCRIPTION
Brief overview:
1. **Resistome counting now uses `alignment_analyzer.py` (AlignmentAnalyzer), replacing the compiled `resistomeanalyzer` binary.** The new analyzer reads the BAM directly and produces the gene-level count matrix, with several improvements to *how* alignments are turned into counts (items 2–4 below). The old `resistomeanalyzer` binary is no longer used for gene counting.
2. **Fragment-level counting — a major change to how hits are counted.** AMR++ now counts at the *fragment* level rather than counting every read as a separate hit.
   - Previously: every aligned read counted as one hit, so a paired-end fragment (R1 + R2) could be counted twice while a merged read counted once — inflating and skewing counts between library types.
   - Now: a read pair and a merged read each count as **one hit**, so paired-end and merged data are directly comparable. This is the default (`count_mode = "fragment"`).
   - When a fragment's two mates map to different-but-near-identical gene accessions in the same MEGARes **Group** (a common database-redundancy artifact), the hit is collapsed to one gene (`group_aware = "Y"`) rather than double-counted. Mates mapping to genuinely different Groups are counted once to each.
   - Query coverage is now "edge-aware" (`edge_aware_qcov = "Y"`): a read that aligns cleanly but runs off the end of a short gene isn't penalized for the overhanging portion. All three behaviors can be turned off (`count_mode = read_end`, `group_aware = "N"`, `edge_aware_qcov = "N"`).
3. **Only primary alignments are counted** for the resistome (secondary/supplementary alignments are excluded by default).
4. Changed default AMR gene fraction `--threshold` to `0`, and added query-coverage / gene-fraction filters to the analyzer (`--min_gene_fraction`, `--min_query_coverage`, both on a 0–1 proportion scale). We recommend running statistical analysis of count matrices after aggregating to the "Group" level to account for possible false-positive calls of individual gene accessions.
5. **Deduplication: alignment deduplication is no longer run by default — we now recommend read deduplication instead**, particularly when analyzing target-enriched data.
   - **Read deduplication** (`read_dedup = "Y"`, Clumpify, applied after QC trimming) more directly addresses PCR duplication by collapsing reads that are actual sequence duplicates.
   - **Alignment deduplication** (`deduped`) produced a larger overall reduction in read numbers, but that reduction included reads that were **not** true duplicates — reads could be collapsed based on alignment coordinates/length rather than being genuine PCR duplicates. Because of this over-collapsing, it is no longer the default recommendation.
   - Alignment deduplication is still available for comparison via `deduped = "Y"`; read deduplication is the recommended approach.
6. Added single-end and merged-read analysis.
7. Changed defaults to skip rarefaction analysis, but default to running SNP confirmation.
8. **Updated SNP confirmation tool (on a separate branch).** The SNP verifier now adjusts counts by the *proportion of reads that actually carry the confirmed SNP*: it computes (reads with the SNP / reads covering the SNP position) and multiplies by the gene's count, rather than substituting a raw resistant-read count. Genes that require SNP confirmation but have no entry in the SNP database are now set to zero (previously they passed through unconfirmed). The tool has also been updated to run cleanly under **Nextflow DSL2 syntax**.
9. **New coverage-threshold sweep workflow (`bam_coverage_sweep`).** Runs a set of pre-aligned BAMs across a grid of gene-fraction and query-coverage thresholds, then produces combined matrices and drop-off plots showing how the resistome (genes, classes, mechanisms, groups) shrinks as thresholds tighten — a way to choose sensible cutoffs and see each sample's sensitivity to them.
10. Update code structure to work with updated nextflow syntax rules. 